### PR TITLE
feat: add .agents-plugin manifest for Codex support

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -1,0 +1,43 @@
+{
+  "name": "grafana-skills",
+  "owner": {
+    "name": "Grafana Labs",
+    "email": "opensource@grafana.com"
+  },
+  "metadata": {
+    "description": "Public skills for working with Grafana, Prometheus, Loki, Tempo, and the broader LGTM stack",
+    "version": "0.1.0"
+  },
+  "plugins": [
+    {
+      "name": "grafana-core",
+      "source": "./",
+      "description": "Skills for core Grafana concepts — dashboards, panels, PromQL, and visualization",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": ["grafana", "dashboards", "promql", "panels"],
+      "skills": []
+    },
+    {
+      "name": "grafana-cloud",
+      "source": "./",
+      "description": "Skills for Grafana Cloud — Loki, Tempo, Pyroscope, and the LGTM observability stack",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": ["grafana-cloud", "loki", "tempo", "pyroscope", "lgtm"],
+      "skills": []
+    },
+    {
+      "name": "grafana-plugins",
+      "source": "./",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, and plugin development",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": ["grafana", "plugins", "bundle-size", "webpack", "code-splitting"],
+      "skills": [
+        "./skills/grafana-plugins/plugin-bundle-size",
+        "./skills/grafana-plugins/react-19-plugin-migration"
+      ]
+    }
+  ]
+}

--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -6,7 +6,8 @@
   },
   "metadata": {
     "description": "Public skills for working with Grafana, Prometheus, Loki, Tempo, and the broader LGTM stack",
-    "version": "0.1.0"
+    "version": "0.1.0",
+    "documentation": "This marketplace manifest must remain identical to the plugin manifests in .claude-plugin/ and .cursor-plugin/. Keep all three manifests in sync."
   },
   "plugins": [
     {

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,6 +21,9 @@ jobs:
           echo "Validating Cursor marketplace.json..."
           jq empty .cursor-plugin/marketplace.json
 
+          echo "Validating Codex marketplace.json..."
+          jq empty .agents-plugin/marketplace.json
+
       - name: Validate marketplace structure
         run: |
           echo "Checking required marketplace fields..."
@@ -65,15 +68,16 @@ jobs:
 
           echo "All SKILL.md files are valid"
 
-      - name: Validate dual-format consistency
+      - name: Validate multi-format consistency
         run: |
-          echo "Checking version consistency between Claude Code and Cursor formats..."
+          echo "Checking version consistency across all marketplace formats..."
 
           CLAUDE_VER=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
           CURSOR_VER=$(jq -r '.metadata.version' .cursor-plugin/marketplace.json)
+          AGENTS_VER=$(jq -r '.metadata.version' .agents-plugin/marketplace.json)
 
-          if [ "$CLAUDE_VER" != "$CURSOR_VER" ]; then
-            echo "ERROR: Marketplace versions don't match (Claude: $CLAUDE_VER, Cursor: $CURSOR_VER)"
+          if [ "$CLAUDE_VER" != "$CURSOR_VER" ] || [ "$CLAUDE_VER" != "$AGENTS_VER" ]; then
+            echo "ERROR: Marketplace versions don't match (Claude: $CLAUDE_VER, Cursor: $CURSOR_VER, Codex: $AGENTS_VER)"
             exit 1
           fi
 
@@ -85,9 +89,10 @@ jobs:
             PLUGIN_NAME=$(jq -r ".plugins[$i].name" .claude-plugin/marketplace.json)
             CLAUDE_PLUGIN_VER=$(jq -r ".plugins[$i].version // \"\"" .claude-plugin/marketplace.json)
             CURSOR_PLUGIN_VER=$(jq -r ".plugins[$i].version // \"\"" .cursor-plugin/marketplace.json)
+            AGENTS_PLUGIN_VER=$(jq -r ".plugins[$i].version // \"\"" .agents-plugin/marketplace.json)
 
-            if [ "$CLAUDE_PLUGIN_VER" != "$CURSOR_PLUGIN_VER" ]; then
-              echo "ERROR: Plugin '$PLUGIN_NAME' versions don't match (Claude: $CLAUDE_PLUGIN_VER, Cursor: $CURSOR_PLUGIN_VER)"
+            if [ "$CLAUDE_PLUGIN_VER" != "$CURSOR_PLUGIN_VER" ] || [ "$CLAUDE_PLUGIN_VER" != "$AGENTS_PLUGIN_VER" ]; then
+              echo "ERROR: Plugin '$PLUGIN_NAME' versions don't match (Claude: $CLAUDE_PLUGIN_VER, Cursor: $CURSOR_PLUGIN_VER, Codex: $AGENTS_PLUGIN_VER)"
               exit 1
             fi
 
@@ -100,6 +105,7 @@ jobs:
           echo "=== Validation Summary ==="
           echo "Claude Code marketplace: .claude-plugin/marketplace.json"
           echo "Cursor marketplace:      .cursor-plugin/marketplace.json"
+          echo "Codex marketplace:       .agents-plugin/marketplace.json"
           echo "Plugins: $(jq '.plugins | length' .claude-plugin/marketplace.json)"
           SKILL_COUNT=$(find skills -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ')
           echo "Skills:  $SKILL_COUNT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ Skills cover Grafana, Prometheus, Loki, Tempo, Pyroscope, k6, and the broader LG
 ```
 .claude-plugin/marketplace.json    # Claude Code marketplace manifest
 .cursor-plugin/marketplace.json    # Cursor marketplace manifest (identical content)
+.agents-plugin/marketplace.json    # Codex marketplace manifest (identical content)
 skills/                            # All skills, grouped by plugin
   <plugin-name>/
     <skill-name>/
@@ -27,8 +28,8 @@ scripts/lint-skills.sh             # Validates SKILL.md files
 
 **Key architecture:**
 
-- Single source of truth in `skills/` — both Claude Code and Cursor reference the same content
-- Dual marketplace manifests (`.claude-plugin/` and `.cursor-plugin/`) with identical content
+- Single source of truth in `skills/` — Claude Code, Cursor, and Codex all reference the same content
+- Three marketplace manifests (`.claude-plugin/`, `.cursor-plugin/`, `.agents-plugin/`) with identical content
 - `skills/` is the conventional directory used by all major agent tools
 
 ## How Skills Work
@@ -126,7 +127,7 @@ Any tool supporting the [Agent Skills](https://agentskills.io) standard or the `
 - Put "When to Use" sections in the skill body (put in `description` frontmatter instead)
 - Add internal Grafana tooling, credentials, or infrastructure-specific content
 - Hardcode script paths — use relative paths or `${CLAUDE_PLUGIN_ROOT}`
-- Edit `.claude-plugin/marketplace.json` without making the identical change to `.cursor-plugin/marketplace.json`
+- Edit `.claude-plugin/marketplace.json` without making the identical change to `.cursor-plugin/marketplace.json` and `.agents-plugin/marketplace.json`
 
 ## Official Resources
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,14 +14,15 @@ Cursor, and other compatible tools.
 grafana-skills/
 ├── .claude-plugin/marketplace.json   # Claude Code marketplace (lists plugin groups)
 ├── .cursor-plugin/marketplace.json   # Cursor marketplace (identical content)
+├── .agents-plugin/marketplace.json   # Codex marketplace (identical content)
 ├── skills/                           # All skills, grouped by plugin
 │   └── <plugin-name>/<skill-name>/SKILL.md
 ├── template/SKILL.md                 # Starter template
 └── scripts/lint-skills.sh            # Local validation
 ```
 
-- **Single source of truth**: All skill content lives in `skills/`. Both Claude Code and Cursor
-  reference the same files via their respective marketplace manifests.
+- **Single source of truth**: All skill content lives in `skills/`. Claude Code, Cursor, and Codex
+  all reference the same files via their respective marketplace manifests.
 - **Grouped by plugin**: Skills are organized under `skills/<plugin-name>/` matching the plugin
   groups in the marketplace manifests (`grafana-core`, `grafana-cloud`, `grafana-plugins`).
 
@@ -52,10 +53,10 @@ Fix any errors or warnings before opening a PR.
 
 ### Step 3: Register in the marketplace (optional but recommended)
 
-Add the skill path to the appropriate plugin's `skills` array in **both** marketplace files:
+Add the skill path to the appropriate plugin's `skills` array in **all three** marketplace files:
 
 ```json
-// .claude-plugin/marketplace.json  AND  .cursor-plugin/marketplace.json
+// .claude-plugin/marketplace.json  AND  .cursor-plugin/marketplace.json  AND  .agents-plugin/marketplace.json
 {
   "plugins": [
     {
@@ -66,7 +67,7 @@ Add the skill path to the appropriate plugin's `skills` array in **both** market
 }
 ```
 
-Keep both files identical.
+Keep all three files identical.
 
 ### Step 4: Open a PR
 
@@ -155,7 +156,7 @@ Do not include:
 ## Adding a New Plugin Group
 
 If your skill doesn't fit `grafana-core`, `grafana-cloud`, or `grafana-plugins`, you can propose
-a new group by adding it to both marketplace files and updating [README.md](README.md).
+a new group by adding it to all three marketplace files and updating [README.md](README.md).
 
 New groups should represent a coherent, installable collection of related skills.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Lint Skills](https://github.com/grafana/skills/actions/workflows/lint-skills.yml/badge.svg)](https://github.com/grafana/skills/actions/workflows/lint-skills.yml)
 
 Public skills for working with Grafana, Prometheus, Loki, Tempo, Pyroscope, k6, and the broader LGTM observability
-stack. Compatible with Claude Code, Cursor, and any tool supporting the
+stack. Compatible with Claude Code, Cursor, Codex, and any tool supporting the
 [Agent Skills](https://agentskills.io) open standard.
 
 ## Installation
@@ -29,6 +29,16 @@ claude plugin install grafana-cloud@grafana-skills
 4. Enter: `https://github.com/grafana/skills`
 
 Skills stay synced with the repository automatically.
+
+### Codex
+
+Skills are discovered automatically via the `.agents-plugin/marketplace.json` manifest. No manual setup needed — Codex loads matching skills based on your task context.
+
+To install manually into a repo's `.agents/skills/` directory:
+
+```bash
+npx skills add grafana/skills
+```
 
 ### npx skills (and other tools)
 
@@ -85,6 +95,7 @@ Quick start:
 grafana-skills/
 ├── .claude-plugin/marketplace.json   # Claude Code marketplace manifest
 ├── .cursor-plugin/marketplace.json   # Cursor marketplace manifest (identical)
+├── .agents-plugin/marketplace.json   # Codex marketplace manifest (identical)
 ├── skills/                           # All skills, grouped by plugin
 │   ├── grafana-core/
 │   ├── grafana-cloud/


### PR DESCRIPTION
## Summary

- Adds `.agents-plugin/marketplace.json` mirroring the existing `.claude-plugin/` and `.cursor-plugin/` manifests
- Enables Codex (and any other tool following the [Agent Skills](https://agentskills.io) standard) to discover and auto-load skills from this repo
- No content changes — same skill paths as the Claude Code and Cursor manifests

## Related

Companion PR to grafana/ai-kit for the same change: adds Codex support across Grafana's public skill repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)