### PR TITLE
docs: add skill links and missing k6 skill in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Core Grafana concepts — dashboards, visualization, PromQL, alerting, and telem
 
 | Skill | Description |
 |-------|-------------|
-| `grafana-oss` | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration |
-| `dashboarding` | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds |
-| `promql` | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics |
-| `alerting-irm` | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
-| `alloy` | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines |
-| `beyla` | Grafana Beyla eBPF auto-instrumentation for zero-code application observability |
-| `opentelemetry` | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors |
+| [grafana-oss](skills/grafana-core/grafana-oss) | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration |
+| [dashboarding](skills/grafana-core/dashboarding) | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds |
+| [promql](skills/grafana-core/promql) | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics |
+| [alerting-irm](skills/grafana-core/alerting-irm) | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
+| [alloy](skills/grafana-core/alloy) | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines |
+| [beyla](skills/grafana-core/beyla) | Grafana Beyla eBPF auto-instrumentation for zero-code application observability |
+| [opentelemetry](skills/grafana-core/opentelemetry) | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors |
 
 ### grafana-cloud
 
@@ -77,21 +77,21 @@ Grafana Cloud — fleet management, cloud integrations, cost optimization, and A
 
 | Skill | Description |
 |-------|-------------|
-| `admin` | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts |
-| `send-data` | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs |
-| `fleet-management` | Manage Grafana Alloy collector fleets with remote configuration and OpAMP |
-| `cloud-integrations` | Connect AWS, Azure, and other cloud providers to Grafana Cloud |
-| `infrastructure` | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations |
-| `app-observability` | Application Observability (APM), Frontend Observability (Faro), and AI Observability |
-| `database-observability` | Query-level performance insights for MySQL and PostgreSQL |
-| `adaptive-metrics` | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management |
-| `cost-management` | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization |
-| `dpm-finder` | Identify Prometheus metrics driving high Data Points per Minute (DPM) |
-| `oncall-irm` | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle |
-| `ml-ai` | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin |
-| `assistant-mcp` | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |
-| `private-connectivity` | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
-| `testing` | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability |
+| [admin](skills/grafana-cloud/admin) | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts |
+| [send-data](skills/grafana-cloud/send-data) | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs |
+| [fleet-management](skills/grafana-cloud/fleet-management) | Manage Grafana Alloy collector fleets with remote configuration and OpAMP |
+| [cloud-integrations](skills/grafana-cloud/cloud-integrations) | Connect AWS, Azure, and other cloud providers to Grafana Cloud |
+| [infrastructure](skills/grafana-cloud/infrastructure) | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations |
+| [app-observability](skills/grafana-cloud/app-observability) | Application Observability (APM), Frontend Observability (Faro), and AI Observability |
+| [database-observability](skills/grafana-cloud/database-observability) | Query-level performance insights for MySQL and PostgreSQL |
+| [adaptive-metrics](skills/grafana-cloud/adaptive-metrics) | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management |
+| [cost-management](skills/grafana-cloud/cost-management) | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization |
+| [dpm-finder](skills/grafana-cloud/dpm-finder) | Identify Prometheus metrics driving high Data Points per Minute (DPM) |
+| [oncall-irm](skills/grafana-cloud/oncall-irm) | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle |
+| [ml-ai](skills/grafana-cloud/ml-ai) | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin |
+| [assistant-mcp](skills/grafana-cloud/assistant-mcp) | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |
+| [private-connectivity](skills/grafana-cloud/private-connectivity) | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
+| [testing](skills/grafana-cloud/testing) | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability |
 
 ### grafana-lgtm
 
@@ -99,11 +99,11 @@ Open-source LGTM observability stack — Loki, Tempo, Prometheus/Mimir, and Pyro
 
 | Skill | Description |
 |-------|-------------|
-| `loki` | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture |
-| `tempo` | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations |
-| `prometheus` | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir |
-| `mimir` | Scalable long-term metrics storage with Grafana Mimir — architecture and operations |
-| `pyroscope` | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
+| [loki](skills/grafana-lgtm/loki) | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture |
+| [tempo](skills/grafana-lgtm/tempo) | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations |
+| [prometheus](skills/grafana-lgtm/prometheus) | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir |
+| [mimir](skills/grafana-lgtm/mimir) | Scalable long-term metrics storage with Grafana Mimir — architecture and operations |
+| [pyroscope](skills/grafana-lgtm/pyroscope) | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
 
 ### grafana-plugins
 
@@ -111,9 +111,9 @@ Skills for building Grafana plugins — bundle optimisation, code splitting, Rea
 
 | Skill | Description |
 |-------|-------------|
-| `plugin-bundle-size` | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
-| `react-19-plugin-migration` | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13 |
-| `grafana-scenes` | Build Grafana plugin pages using the @grafana/scenes framework |
+| [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size) | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
+| [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13 |
+| [grafana-scenes](skills/grafana-plugins/grafana-scenes) | Build Grafana plugin pages using the @grafana/scenes framework |
 
 ### grafana-app-sdk
 
@@ -121,10 +121,10 @@ Skills for building apps on the Grafana App Platform using grafana-app-sdk.
 
 | Skill | Description |
 |-------|-------------|
-| `app-sdk-concepts` | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
-| `cue-kind-definition` | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config |
-| `reconciler-logic` | Implement async reconciler and watcher business logic |
-| `admission-control` | Write validation and mutation admission handlers |
+| [app-sdk-concepts](skills/grafana-app-sdk/app-sdk-concepts) | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
+| [cue-kind-definition](skills/grafana-app-sdk/cue-kind-definition) | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config |
+| [reconciler-logic](skills/grafana-app-sdk/reconciler-logic) | Implement async reconciler and watcher business logic |
+| [admission-control](skills/grafana-app-sdk/admission-control) | Write validation and mutation admission handlers |
 
 ### grafana-k6
 
@@ -132,7 +132,8 @@ Skills for working with k6 open-source load testing.
 
 | Skill | Description |
 |-------|-------------|
-| `k6-docs` | Write or review k6 documentation across TypeScript types, user docs, and release notes |
+| [k6](skills/grafana-k6/k6) | k6 performance and load testing — test scripts, executors, thresholds, scenarios, and k6 Cloud execution |
+| [k6-docs](skills/grafana-k6/k6-docs) | Write or review k6 documentation across TypeScript types, user docs, and release notes |
 
 ---
 


### PR DESCRIPTION
Follow-up to #18.

## Changes

- **Skill names are now links** — every entry in all skill tables links to its directory in the repo, making it easy to jump straight to a skill file
- **Add missing `k6` skill** to the `grafana-k6` section — the directory `skills/grafana-k6/k6/` exists but was not listed in the README

No content changes to descriptions.