### PR TITLE
docs: fix Cursor install instructions to use `npx skills`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,15 @@ claude plugin install grafana-k6@grafana-skills
 
 ### Cursor
 
-1. Open **Cursor Settings** - **Rules, Skills, Subagents**
-2. Click **+ New** next to **Rules**
-3. Select **Add from GitHub**
-4. Enter: `https://github.com/grafana/skills`
+Install via the `npx skills` command shown above:
 
-Skills stay synced with the repository automatically.
+```bash
+npx skills add grafana/skills
+```
+
+This writes skills into `.cursor/skills/` in your project so Cursor's agent can load them.
+
+> Cursor's built-in **Add Rule → Remote Rule (Github)** flow is not compatible with this repository. That importer only accepts Cursor Project Rules (`.mdc` files under `.cursor/rules/`), and the Grafana Skills repo follows the [Agent Skills](https://agentskills.io) standard instead (`SKILL.md` files under `skills/`).
 
 ### Codex and other Agent Skills tools
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npx skills add grafana/skills
 
 This writes skills into `.cursor/skills/` in your project so Cursor's agent can load them.
 
-> Cursor's built-in **Add Rule → Remote Rule (Github)** flow is not compatible with this repository. That importer only accepts Cursor Project Rules (`.mdc` files under `.cursor/rules/`), and the Grafana Skills repo follows the [Agent Skills](https://agentskills.io) standard instead (`SKILL.md` files under `skills/`).
+> Cursor's built-in **Add Rule → Remote Rule (GitHub)** flow is not compatible with this repository. That importer only accepts Cursor Project Rules (`.mdc` files under `.cursor/rules/`), and the Grafana Skills repo follows the [Agent Skills](https://agentskills.io) standard instead (`SKILL.md` files under `skills/`).
 
 ### Codex and other Agent Skills tools
 


### PR DESCRIPTION
## Summary

Fixes [#21](https://github.com/grafana/skills/issues/21).

The README's Cursor install steps sent users into Cursor's **Add Rule → Remote Rule (Github)** flow. That importer only accepts Cursor Project Rules (`.mdc` files under `.cursor/rules/`), but this repo ships [Agent Skills](https://agentskills.io) (`SKILL.md` files under `skills/`). Cursor therefore reports:

> Failed to import GitHub/GitLab rules: No importable `.mdc` project rule files were found in the repository.

Two issues with the previous block:

1. **Wrong importer.** Cursor has no separate "Skills" feature today — only Rules — and the Rules importer can't read this repo. Verified against the current Cursor docs at <https://cursor.com/docs/context/rules>.
2. **Wrong settings tab name.** Cursor's settings tab is "Rules, Commands", not "Rules, Skills, Subagents".

This PR replaces the broken UI flow with the `npx skills add grafana/skills` path that is already the recommended install at the top of the README, and adds a short note explaining why the Rules importer doesn't work for this repo.

## Test plan

- [ ] Visual review of the updated README section
- [ ] Run `npx skills add grafana/skills` from a Cursor project and confirm skills land in `.cursor/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)