### PR TITLE
Amend Alloy skill wrt clustering

### DIFF
--- a/skills/grafana-core/alloy/SKILL.md
+++ b/skills/grafana-core/alloy/SKILL.md
@@ -225,11 +225,19 @@ utils.my_component "example" {
 
 ## Clustering
 
-```alloy
-clustering {
-  enabled = true
-}
+Making Alloy aware of peers for clustering and distributing the workload,
+requires setting command-line flags to the `run` command or the system service
+definition.
 
+At minimum, these are the `--cluster.enabled` flag to enable the clustering
+service, and one of `--cluster.join-addresses` or `--cluster.discover-peers` to
+instruct Alloy how to join the cluster. Look at the rest of the `--cluster.*`
+flags to fine-tune the clustering behavior.
+
+With Alloy clustering, cluster-aware components can use the `clustering` block
+to set `enabled=true` and distribute the workload within cluster members.
+
+```alloy
 prometheus.scrape "cluster_aware" {
   targets    = discovery.kubernetes.pods.targets
   forward_to = [prometheus.remote_write.cloud.receiver]


### PR DESCRIPTION
The clustering service is not configurable (like other services) via a top-level configuration block, but rather depends on command-line flags passed to the `run` command for enabling clustering, discovering peers and fine-tuning other clustering characteristics.

This PR amends the clustering section of the grafana-alloy skill so that it does not produce invalid configuration, and also hints at how to configure clustering to be used properly both on Alloy itself as well as supported components.