### PR TITLE
feat(skills): add Prometheus label strategy and cardinality troubleshooter

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -69,7 +69,9 @@
         "./skills/grafana-cloud/cost-management",
         "./skills/grafana-cloud/oncall-irm",
         "./skills/grafana-cloud/dpm-finder",
-        "./skills/grafana-cloud/loki-label-analyzer"
+        "./skills/grafana-cloud/loki-label-analyzer",
+        "./skills/grafana-cloud/prometheus-label-strategy",
+        "./skills/grafana-cloud/prometheus-cardinality-troubleshooter"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -69,7 +69,9 @@
         "./skills/grafana-cloud/cost-management",
         "./skills/grafana-cloud/oncall-irm",
         "./skills/grafana-cloud/dpm-finder",
-        "./skills/grafana-cloud/loki-label-analyzer"
+        "./skills/grafana-cloud/loki-label-analyzer",
+        "./skills/grafana-cloud/prometheus-label-strategy",
+        "./skills/grafana-cloud/prometheus-cardinality-troubleshooter"
       ]
     },
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -69,7 +69,9 @@
         "./skills/grafana-cloud/cost-management",
         "./skills/grafana-cloud/oncall-irm",
         "./skills/grafana-cloud/dpm-finder",
-        "./skills/grafana-cloud/loki-label-analyzer"
+        "./skills/grafana-cloud/loki-label-analyzer",
+        "./skills/grafana-cloud/prometheus-label-strategy",
+        "./skills/grafana-cloud/prometheus-cardinality-troubleshooter"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Grafana Cloud — fleet management, cloud integrations, cost optimization, and A
 | [cost-management](skills/grafana-cloud/cost-management) | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization |
 | [dpm-finder](skills/grafana-cloud/dpm-finder) | Identify Prometheus metrics driving high Data Points per Minute (DPM) |
 | [loki-label-analyzer](skills/grafana-cloud/loki-label-analyzer) | Evaluate and improve Loki label strategy using cardinality, query patterns, and label hygiene |
+| [prometheus-label-strategy](skills/grafana-cloud/prometheus-label-strategy) | Audit and design Prometheus label schemas — cardinality, histograms, source-side prevention |
+| [prometheus-cardinality-troubleshooter](skills/grafana-cloud/prometheus-cardinality-troubleshooter) | Diagnose live Prometheus cardinality issues — slow queries, OOMs, high Active Series bills |
 | [oncall-irm](skills/grafana-cloud/oncall-irm) | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle |
 | [ml-ai](skills/grafana-cloud/ml-ai) | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin |
 | [assistant-mcp](skills/grafana-cloud/assistant-mcp) | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |

--- a/skills/grafana-cloud/prometheus-cardinality-troubleshooter/SKILL.md
+++ b/skills/grafana-cloud/prometheus-cardinality-troubleshooter/SKILL.md
@@ -1,0 +1,421 @@
+---
+name: prometheus-cardinality-troubleshooter
+license: Apache-2.0
+description: >
+  Diagnostic guide for active Prometheus cardinality problems — slow queries, OOMing
+  Prometheus, high Grafana Cloud Active Series or DPM bills, "too many samples" ingest
+  errors, series churn, or rapid memory growth. Walks through tsdb status endpoints,
+  per-metric and per-label drill-downs, common-culprit galleries, and remediation paths.
+  Use when the user is *currently experiencing* a cardinality fire. For preventing
+  cardinality issues at the source, route to prometheus-label-strategy. For post-ingest
+  aggregation, route to adaptive-metrics. For DPM-specific analysis, route to dpm-finder.
+---
+
+# Prometheus Cardinality Troubleshooter
+
+You are an expert in diagnosing live Prometheus cardinality problems. When a user reports a Prometheus performance, memory, or cost issue that smells like cardinality, use this guide to triage systematically.
+
+This skill is **diagnostic and operational**. For schema design and prevention, route to `prometheus-label-strategy`.
+
+---
+
+## Symptom → Likely Cause
+
+| Symptom | Likely Cause | First Action |
+|---|---|---|
+| Prometheus OOMKilled or memory growing linearly | Active series growth (often from a new bad metric or label) | [Active Series triage](#step-1-active-series-triage) |
+| Single PromQL query slow or OOMs the querier | One or more metrics in the query have high cardinality | [Per-query drill-down](#step-3-per-metric-drill-down) |
+| Remote write lagging, WAL growing | Sample throughput spike — series count OR scrape interval changed | [Active Series triage](#step-1-active-series-triage) + check scrape intervals |
+| `429 Too Many Samples` / `out of bounds` errors | Hitting Mimir/Cortex ingester per-tenant series limit | [Per-metric drill-down](#step-3-per-metric-drill-down), find the new offender |
+| Grafana Cloud Active Series bill spiked | New metric, new label, or rollout creating churn | [Per-metric drill-down](#step-3-per-metric-drill-down) + churn check |
+| Grafana Cloud DPM bill spiked but Active Series flat | Scrape interval shortened, OR remote_write sending duplicates | DPM-side issue — route to `dpm-finder` |
+| `series_limit_per_user` errors after a deploy | Application change introduced a new bad label | [Recent change diff](#step-4-recent-change-diff) |
+| Series count grows then resets every restart | Series churn from ephemeral label values | [Churn diagnosis](#step-5-churn-diagnosis) |
+
+---
+
+## Step 1: Active Series Triage
+
+### Get the headline number
+
+```promql
+# Total active series in the local Prometheus
+prometheus_tsdb_head_series
+
+# Or for Mimir / Grafana Cloud Metrics (per tenant)
+cortex_ingester_memory_series{user="<tenant>"}
+```
+
+Compare to recent history:
+```promql
+# Growth over the last 7 days
+deriv(prometheus_tsdb_head_series[7d]) * 86400
+```
+
+A growth rate > a few % per day on a stable application set is a red flag.
+
+### Use the TSDB status endpoint
+
+Prometheus exposes a built-in cardinality breakdown:
+
+```bash
+curl -s http://prometheus:9090/api/v1/status/tsdb | jq
+```
+
+Returns:
+- `seriesCountByMetricName` — top metrics by series count
+- `labelValueCountByLabelName` — top labels by unique value count
+- `memoryInBytesByLabelName` — top labels by memory footprint
+- `seriesCountByLabelValuePair` — top label-value pairs by series count
+
+This is usually the fastest path to "which metric / which label is the problem."
+
+For Grafana Cloud:
+```bash
+# Same endpoint, authenticated against the per-tenant Mimir
+curl -s -u "<user>:<token>" \
+  "https://prometheus-prod-XX.grafana.net/api/prom/api/v1/status/tsdb" | jq
+```
+
+---
+
+## Step 2: Read the Output
+
+### Top metrics by series count
+
+```json
+"seriesCountByMetricName": [
+  { "name": "http_request_duration_seconds_bucket", "value": 184320 },
+  { "name": "go_gc_duration_seconds",               "value": 80 },
+  ...
+]
+```
+
+**Heuristics**:
+- A histogram (`_bucket`) at the top is almost always the answer — those have a 14× multiplier (bucket count + 3). The fix is usually **trimming labels on the underlying histogram**, not the buckets themselves.
+- A metric in the top 5 you don't recognize → grep the codebase for it; it's likely a new feature flag or a debug metric that shipped to prod
+- The same metric showing up under multiple variants (`_total`, `_count`, `_sum`) — that's a histogram or summary, count all variants together for the true impact
+
+### Top labels by unique value count
+
+```json
+"labelValueCountByLabelName": [
+  { "name": "url",       "value": 84210 },
+  { "name": "trace_id",  "value": 41000 },
+  { "name": "pod",       "value": 1820 }
+]
+```
+
+**Red flags**:
+- Any label with >10K unique values is almost certainly a bug. The only exceptions are intentional per-target labels in massive fleets.
+- `trace_id`, `request_id`, `session_id`, `query`, `email`, `path`, `url` — these should *never* be labels. They belong in exemplars, logs, or traces.
+- `pod` with thousands of values — see [Churn diagnosis](#step-5-churn-diagnosis); recent churn often inflates this number
+
+---
+
+## Step 3: Per-Metric Drill-Down
+
+Once you've identified a suspect metric, find which label is responsible.
+
+### Count distinct label values per label, for one metric
+
+```promql
+# How many unique values does each label have on this metric?
+count by (__name__) (
+  count by (__name__, label_name_here) (
+    http_request_duration_seconds_bucket
+  )
+)
+```
+
+Repeat per label, or use the helper:
+
+```bash
+# Via the Prometheus HTTP API
+curl -s "http://prometheus:9090/api/v1/labels?match[]=http_request_duration_seconds_bucket" | jq -r '.data[]' | \
+  while read label; do
+    count=$(curl -s "http://prometheus:9090/api/v1/label/${label}/values?match[]=http_request_duration_seconds_bucket" | jq '.data | length')
+    echo "${count}  ${label}"
+  done | sort -rn | head -20
+```
+
+### Find the top label values for one label
+
+```promql
+# Top 20 path values for http_requests_total
+topk(20,
+  count by (path) (http_requests_total)
+)
+```
+
+If you see UUIDs, hashes, timestamps, or numeric IDs in the top values → that label has unbounded values from the source.
+
+### Per-metric series count, grouped
+
+```promql
+# Series-per-instance breakdown — if uneven, one instance is misbehaving
+sum by (job, instance) ({__name__=~"my_metric.*"})
+```
+
+---
+
+## Step 4: Recent Change Diff
+
+If the cardinality fire started recently, the cause is almost always a recent change. Diff what's there now against what was there before.
+
+### List of metrics, current vs. yesterday
+
+Via Grafana Cloud cardinality dashboard, or:
+```promql
+# Current metrics
+group by (__name__) ({__name__!=""})
+
+# Compare to last week (offset)
+group by (__name__) ({__name__!=""} offset 7d)
+```
+
+Diff externally. A new metric near the top of `seriesCountByMetricName` that wasn't there a week ago → that's your offender.
+
+### Correlate with deploys
+
+```promql
+# Active series correlated with build_info
+prometheus_tsdb_head_series
+# Overlay with:
+changes(app_build_info[1d])
+```
+
+A vertical step in series count aligned with a deploy is conclusive.
+
+---
+
+## Step 5: Churn Diagnosis
+
+High churn means series are being created and abandoned faster than they age out. Symptoms: series count keeps climbing, then drops sharply on Prometheus restart.
+
+### Churn signal
+
+```promql
+# Series created vs. removed per second
+rate(prometheus_tsdb_head_series_created_total[5m])
+rate(prometheus_tsdb_head_series_removed_total[5m])
+
+# Ratio of churned to live
+prometheus_tsdb_head_series_created_total / prometheus_tsdb_head_series
+```
+
+A creation rate that materially exceeds the removal rate, sustained, means cardinality is on a one-way trip up. Common causes:
+
+| Cause | Tell |
+|---|---|
+| Pod rollouts emitting `pod` label | Churn spike aligns with deploy timing; affects pod-discovered scrapes |
+| `version` / `git_sha` / `image_tag` label on every metric | Churn spike on every deploy across many metrics |
+| Ephemeral hostnames in `instance` | Cloud autoscaling event timing |
+| Bug: dynamic label names | Churn climbs forever, never plateaus |
+| Application bug emitting fresh UUIDs as labels | Linear unbounded growth, no deploy correlation |
+
+### Memory impact of churn
+
+```promql
+# A churn-driven head block carries old series until tsdb compaction
+prometheus_tsdb_head_chunks
+go_memstats_heap_inuse_bytes{job="prometheus"}
+```
+
+Restarting Prometheus drops churned series but is not a fix. The fix is at the source.
+
+---
+
+## Common-Culprit Gallery
+
+### Histogram blowup
+
+**Tell**: `*_bucket` metric at the top of `seriesCountByMetricName`. Multiplier ≈ 14×.
+
+**Fix**:
+1. First, **reduce labels on the histogram** — every label removed saves 14× series. Trim `path`, `method`, or `status_code` before touching bucket count.
+2. Then, reduce bucket count if appropriate (custom buckets vs. defaults).
+3. For high-resolution latency tracking, consider **native histograms** (Prometheus 2.40+) — single sparse series replaces the bucket family.
+
+### kube-state-metrics label explosion
+
+**Tell**: `kube_pod_labels` or `kube_pod_annotations` at the top, with `label_*` or `annotation_*` labels driving cardinality.
+
+**Fix**: configure kube-state-metrics with `--metric-labels-allowlist` and `--metric-annotations-allowlist`. By default it emits *all* labels and annotations as series.
+
+```yaml
+# kube-state-metrics flags
+--metric-labels-allowlist=pods=[app,team,version]
+--metric-annotations-allowlist=pods=[checksum/config]
+```
+
+### Path / route blowup from a new endpoint
+
+**Tell**: `http_requests_total` (or framework equivalent) grew 10×+ overnight. `topk(20, count by (path) (http_requests_total))` shows hundreds of `/users/123456`-style values.
+
+**Fix**: route the user to `prometheus-label-strategy` for the long-term fix (template paths in code). For the immediate stop:
+
+```yaml
+# In Prometheus scrape config — emergency drop
+metric_relabel_configs:
+  - source_labels: [__name__, path]
+    regex: http_requests_total;/users/\d+
+    action: drop
+```
+
+Or normalize via relabel:
+```yaml
+metric_relabel_configs:
+  - source_labels: [path]
+    regex: /users/\d+
+    target_label: path
+    replacement: /users/:id
+```
+
+### Application emitting a debug metric in prod
+
+**Tell**: A metric you don't recognize in the top 10. Grep the source — often a `_details` or `_per_request` debug metric the developer forgot to gate.
+
+**Fix**: drop entirely at scrape:
+```yaml
+metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: my_app_request_details
+    action: drop
+```
+
+Open a ticket against the team to remove it from the code.
+
+### Broken relabel rule allowing app-emitted target labels
+
+**Tell**: Series count for one job is several × what it should be. Looking at one series, you see both an app-emitted `instance=...` AND the target `instance=...` collided into something weird.
+
+**Fix**: ensure your `metric_relabel_configs` drops the labels that should come only from targets:
+```yaml
+metric_relabel_configs:
+  - regex: (instance|pod|node|host|job)
+    action: labeldrop
+```
+
+Then the target labels from `relabel_configs` apply cleanly.
+
+### Federation amplifying cardinality
+
+**Tell**: A federated Prometheus or Mimir global view has way more series than expected. Each source has its own `cluster` / `region` label, multiplying.
+
+**Fix**: this is usually expected — federation by design preserves source labels. If the series count is too high, federate only aggregated recording rules, not raw metrics:
+
+```yaml
+- job_name: federate
+  honor_labels: true
+  metrics_path: /federate
+  params:
+    'match[]':
+      - '{__name__=~".*:.*"}'  # Recording-rule naming convention only
+```
+
+---
+
+## Remediation Decision Tree
+
+```
+Cardinality fire confirmed
+│
+├── Need to stop the bleeding NOW (production OOM, ingest 429s)
+│   └── Apply emergency drop via metric_relabel_configs at scrape config
+│       (also applies to Alloy/Agent — same syntax)
+│       Then schedule the proper fix.
+│
+├── It's a Grafana Cloud Active Series bill issue, not a perf issue
+│   ├── Cardinality is structural and you can't fix the app
+│   │   └── Route to `adaptive-metrics` skill (post-ingest aggregation rules)
+│   └── You want metric-by-metric DPM breakdown
+│       └── Route to `dpm-finder` skill
+│
+├── It's a fixable application bug (unbounded label, debug metric in prod)
+│   ├── Short-term: metric_relabel_configs drop at scrape
+│   └── Long-term: fix in code; route to `prometheus-label-strategy` for design guidance
+│
+├── It's histogram cardinality
+│   ├── Trim labels on the underlying histogram (14× win per label)
+│   ├── Reduce bucket count if appropriate
+│   └── Consider native histograms for high-resolution latency
+│
+└── It's churn (deploy-driven)
+    ├── Remove `pod`, `version`, `git_sha` from application metrics
+    ├── Use info-metric pattern for `version` (route to `prometheus-label-strategy`)
+    └── Verify K8s SD relabel rules aren't carrying `uid` or other ephemeral fields
+```
+
+---
+
+## Emergency Drop Patterns (copy-paste ready)
+
+For Prometheus `scrape_configs`:
+
+```yaml
+metric_relabel_configs:
+  # Drop a specific bad metric
+  - source_labels: [__name__]
+    regex: bad_metric_name
+    action: drop
+
+  # Drop a high-cardinality label from all metrics
+  - regex: bad_label_name
+    action: labeldrop
+
+  # Drop all labels matching a prefix (e.g., debug_*)
+  - regex: debug_.*
+    action: labeldrop
+
+  # Drop a metric only when a specific label has unbounded values
+  - source_labels: [__name__, path]
+    regex: http_requests_total;/users/\d+
+    action: drop
+
+  # Aggregate path patterns to a template (replace the value)
+  - source_labels: [path]
+    regex: /users/\d+
+    target_label: path
+    replacement: /users/:id
+
+  # Aggregate status codes to classes
+  - source_labels: [status_code]
+    regex: (\d)\d\d
+    target_label: status_code
+    replacement: ${1}xx
+```
+
+For Grafana Alloy (`prometheus.relabel` component):
+
+```alloy
+prometheus.relabel "drop_bad_metric" {
+  forward_to = [prometheus.remote_write.default.receiver]
+
+  rule {
+    source_labels = ["__name__"]
+    regex = "bad_metric_name"
+    action = "drop"
+  }
+
+  rule {
+    regex = "bad_label_name"
+    action = "labeldrop"
+  }
+}
+```
+
+**Always test in staging first.** A misconfigured `labeldrop` regex can wipe critical labels across every metric.
+
+---
+
+## When to Hand Off
+
+- **"Now design a label strategy so this doesn't happen again"** → `prometheus-label-strategy`
+- **"We need to keep these metrics but reduce cost"** → `adaptive-metrics`
+- **"Which metric is the most expensive in DPM terms?"** → `dpm-finder`
+- **"Write the PromQL to find this"** → `promql`
+- **"Configure this in Alloy"** → `alloy`
+- **"Why is my Loki slow?"** → `loki-label-analyzer` (different system, same family of problems)
+
+This skill's lane is **diagnosis under pressure**. Prevention, design, and post-ingest cost optimization live elsewhere.

--- a/skills/grafana-cloud/prometheus-label-strategy/SKILL.md
+++ b/skills/grafana-cloud/prometheus-label-strategy/SKILL.md
@@ -1,0 +1,374 @@
+---
+name: prometheus-label-strategy
+license: Apache-2.0
+description: >
+  Expert evaluator for Prometheus label strategy. Audits, designs, and improves label
+  schemas using cardinality scoring, access-pattern alignment, static vs. dynamic label
+  rules, histogram bucket discipline, instrumentation hygiene, and source-side prevention
+  via relabel_config / metric_relabel_configs. Use when the user asks to evaluate, audit,
+  design, or improve Prometheus labels — or asks how to prevent high cardinality at the
+  source. For post-ingest aggregation, see the adaptive-metrics skill. For "why is my
+  Prometheus slow / expensive right now" triage, see prometheus-cardinality-troubleshooter.
+---
+
+# Prometheus Label Strategy Evaluator
+
+You are an expert in Prometheus label strategy. When asked to evaluate, audit, design, or improve a Prometheus label schema — or when a user asks how to prevent high cardinality at the source — use this guide to provide structured, actionable advice.
+
+This skill is about **preventing bad labels at ingest** (instrumentation, scrape configuration, relabeling). For post-ingest cost reduction via aggregation rules, route the user to the `adaptive-metrics` skill. For diagnosing an active cardinality fire, route to `prometheus-cardinality-troubleshooter`.
+
+---
+
+## Core Concepts
+
+**Series** are the fundamental unit in Prometheus. Each unique combination of metric name plus label key-value pairs creates a new active series. Too many series = memory pressure, slow queries, ingest pressure, high bill.
+
+**Cardinality** = the number of unique values a label can have. Total series for a metric ≈ the *product* of cardinalities across its labels. A metric with `path` (100 values), `status_code` (10 values), `method` (5 values), and `instance` (50 values) = **250,000 series per metric**. Adding one more high-cardinality label often 10–100×s the count.
+
+**The dual impact rule**: High-cardinality labels hurt on both paths:
+- **Ingestion path**: More active series → larger head block, larger WAL, more memory, larger remote_write payloads, higher Grafana Cloud bill (Active Series + DPM)
+- **Query path**: PromQL operators (`sum by`, `rate`, joins) must materialize matching series in memory. High cardinality balloons query memory and latency
+
+**Series churn** is the silent killer. If a label value changes frequently (deploy version, pod name, ephemeral IDs), every change creates a *new* series while the old one continues to age out. Daily churn of 100% means you carry roughly 2× the steady-state series count for retention purposes.
+
+**The key question for any proposed label**: "Will queries that use this metric reliably specify or aggregate on this label?" If no → it should NOT be a label.
+
+---
+
+## Label Evaluation Framework
+
+When auditing a label set, assess each label against these criteria.
+
+### Cardinality Scoring
+
+| Label Example | Cardinality | Verdict |
+|---|---|---|
+| `env` (prod/staging/dev) | 2–5 values | ✅ Good |
+| `job` (Prometheus scrape job) | 5–50 values | ✅ Good |
+| `cluster`, `region` | Tens | ✅ Good |
+| `namespace` (K8s) | Tens–low hundreds | ✅ Acceptable |
+| `service`, `workload`, `container` | Tens–hundreds | ✅ Acceptable |
+| `instance` (host:port) | Hundreds–low thousands | ⚠️ Evaluate — fine on per-instance metrics, risky on aggregated ones |
+| `pod` (K8s) | Thousands + transient = high churn | ❌ Drop at scrape unless required |
+| `path` / `route` (HTTP) | Bounded if templated; unbounded if raw URLs | ⚠️ Only with templated values (`/users/:id`) |
+| `version`, `image_tag`, `git_sha` | Grows on every deploy → churn | ⚠️ Use sparingly; consider info-metric pattern |
+| `user_id`, `request_id`, `trace_id` | Unbounded | ❌ Never as label — use exemplars |
+| `customer_id`, `tenant_id` | Often unbounded | ❌ Only acceptable for small fixed tenant counts |
+| `error_message`, `query`, `sql` | Unbounded text | ❌ Never |
+
+### Access Pattern Alignment
+
+For each label, ask:
+- Do queries on this metric reliably aggregate by or filter on this label?
+- Does this label logically segment the metric the way users think about it?
+- Would removing this label force users to use exemplars, logs, or traces instead — and would that be acceptable for the rare lookup case?
+
+### Static vs. Dynamic Label Values
+
+- **Static / target labels** (set once per scrape target via `relabel_configs`, e.g., `env=prod`, `cluster=us-east`, `team=payments`) add cardinality proportional to *targets*, not requests. Cheap and high-value. Use freely.
+- **Dynamic / sample labels** (emitted by the application per measurement, e.g., `status_code`, `method`, `cache_hit`) multiply cardinality by *value count*. Keep possible values in the single digits or low tens. **The application code is the source of truth — fix it there, not in Prometheus.**
+
+### Consistency Check
+
+- Label *names* consistent across services? (`status` vs `status_code` vs `http_status` produces three separate label families — joins break)
+- Label *values* normalized? (`200` vs `"200"`, `GET` vs `get`, `Error` vs `error`)
+- Naming convention consistent? Prometheus convention is `snake_case` for both metric and label names
+- Same concept, same name across services? (`service` vs `svc` vs `app_name`)
+
+### Histogram Bucket Discipline (critical, often missed)
+
+Every histogram metric multiplies its base cardinality by **(bucket count + 3)** — buckets via `_bucket{le="..."}` plus `_sum`, `_count`, and `_created` (Prometheus 2.39+).
+
+- Default `prometheus.DefBuckets` has 11 buckets → **14× multiplier**
+- A histogram with `method`, `path`, `status` already at 1,000 series becomes **14,000 series** after adding histogram cardinality
+- **Always trim histogram label cardinality first** — labels matter 14× more on histograms than on counters/gauges
+- Consider native histograms (Prometheus 2.40+) which use a single sparse series instead of one-per-bucket — major cardinality reduction for high-resolution latency tracking
+
+### Info-Metric Pattern (for high-churn metadata)
+
+When you want to *know* about a label (e.g., `version`, `git_sha`, `image_tag`) without paying for it on every metric, use an info metric:
+
+```
+# A single low-cardinality counter/gauge of value 1, with the metadata attached
+app_build_info{app="payment-api", version="2.4.1", git_sha="a1b2c3"} 1
+```
+
+Then join at query time:
+```promql
+sum by (version) (
+  rate(http_requests_total{app="payment-api"}[5m])
+  * on (app) group_left (version) app_build_info
+)
+```
+
+The `version` label lives on exactly one series per build, not on every metric.
+
+---
+
+## Evaluation Output Format
+
+When auditing a label set, produce a report in this structure:
+
+```
+## Prometheus Label Strategy Audit
+
+### Summary
+[1-2 sentence overall assessment — total estimated active series, biggest risks]
+
+### Per-Label Analysis
+| Metric Family | Label | Cardinality | Used in Queries? | Verdict | Action |
+|---|---|---|---|---|---|
+| http_requests_total | path | Unbounded (raw URLs) | Sometimes | ❌ Remove | Template in code: `/users/:id` not `/users/12345` |
+| http_requests_total | pod | High + churn | Rarely | ❌ Drop via metric_relabel_configs | Already in target metadata |
+
+### Histogram-Specific Findings
+[Highlight any histograms with high label cardinality — these are 14×+ amplified]
+
+### Estimated Impact
+- Active series reduction: [X series → Y series]
+- DPM reduction: [X DPM → Y DPM]  (samples-per-minute = series × ~6 at 10s scrape)
+- Memory impact: [if measurable]
+
+### Recommended Label Set
+[Final recommended labels per metric family]
+
+### Implementation Plan
+1. [Code changes — instrumentation hygiene]
+2. [Scrape config changes — relabel_configs]
+3. [Drop-at-scrape changes — metric_relabel_configs]
+4. [Recording rules to materialize useful aggregates]
+```
+
+---
+
+## Recommended Common Target Labels
+
+These should be set as **target labels** (via `relabel_configs` on the scrape job, NOT emitted by the app) — they're per-target, low cardinality, high query value:
+
+| Label | Purpose | Notes |
+|---|---|---|
+| `job` | Prometheus scrape job name | Set automatically by Prometheus |
+| `instance` | Target endpoint (`host:port`) | Set automatically; rename via `relabel_configs` to a friendlier value if needed |
+| `env` | Environment (`prod`, `staging`, `dev`) | Set via static_configs labels or service discovery |
+| `cluster` | Multi-cluster differentiation | Critical for federation/Mimir multi-tenant |
+| `region` | Geographic region | |
+| `team` / `squad` | Ownership — also useful for access control | |
+| `service` | Logical service identity | One service may span multiple jobs |
+
+These should **NOT** be re-emitted by the application. If the app emits a `cluster` label, it duplicates the target label and creates collisions / `honor_labels` decisions you don't want to make.
+
+---
+
+## Kubernetes Patterns
+
+### Recommended Labels (from kubernetes_sd_configs)
+
+| Label | Source | Notes |
+|---|---|---|
+| `namespace` | Pod metadata | Always keep |
+| `container` | Pod spec | Low cardinality, useful for multi-container pods |
+| `workload` | Derived: `{controller_kind}/{controller_name}` | **Strongly preferred over `pod`** — static, predictable |
+| `service` | K8s Service | If scraping via Service |
+
+### Labels to AVOID by Default in Kubernetes
+
+**`pod` label** ⚠️
+- Highly transient: rolls every deploy and on every restart
+- High cardinality: 100 pods × N metrics = N × 100 series, but on rollouts you carry both old and new pods until they age out
+- Almost never the right query dimension — users want *workload*, not *pod instance*
+- **Solution**: Keep `workload` as a label; drop `pod` via `metric_relabel_configs`; use exemplars or kube-state-metrics for pod-specific lookups
+
+```yaml
+# Drop the pod label from application metrics at scrape time
+metric_relabel_configs:
+  - regex: pod
+    action: labeldrop
+```
+
+**`uid` label** ❌
+- Completely unbounded (regenerates on every pod recreation)
+- No legitimate query use — kept only by accident in default kubernetes_sd configs
+
+**Application-emitted `instance` / `pod` / `node`** ❌
+- These should come from target labels, not from the app code
+- Drop them at scrape with `metric_relabel_configs` or fix in code
+
+**kube-state-metrics annotation / label propagation** ⚠️
+- `kube_pod_labels{label_app_kubernetes_io_*=...}` can carry dozens of metadata labels
+- Each unique pod label combination is a new series
+- Use kube-state-metrics' `--metric-labels-allowlist` to restrict to the labels you actually query on
+
+---
+
+## Source-Side Prevention: Where to Fix What
+
+There are four levers, in **order of preference**:
+
+### 1. Fix in the Application (best)
+
+Bad labels emitted by the app are the root cause. Examples:
+- HTTP paths: use templated routes (`/users/:id`) not raw paths
+- Error metrics: use a small enum (`error_type="timeout"`) not the error message string
+- User-scoped metrics: don't include `user_id` — use exemplars to point to logs/traces
+- Free-form input: never emit user-supplied strings as label values
+
+If you control the code, this is always the right fix. It saves cost on every downstream system (Prometheus, remote_write, Mimir, Grafana Cloud).
+
+### 2. `relabel_configs` (target-time relabeling)
+
+Runs *before* the scrape. Used to:
+- Set target labels (`env`, `cluster`, `team`) on discovered targets
+- Drop entire targets you don't want to scrape
+- Rewrite `instance` to a friendly value
+- Add identity from service discovery metadata
+
+```yaml
+scrape_configs:
+  - job_name: my-app
+    kubernetes_sd_configs:
+      - role: pod
+    relabel_configs:
+      # Set workload from controller metadata
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_controller_name]
+        target_label: workload
+        separator: /
+      # Set env from a pod label
+      - source_labels: [__meta_kubernetes_pod_label_env]
+        target_label: env
+      # Only scrape pods explicitly opted in
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        regex: "true"
+        action: keep
+```
+
+### 3. `metric_relabel_configs` (scrape-time relabeling)
+
+Runs *after* the scrape, *before* storage. Used to:
+- Drop high-cardinality labels the app shouldn't have emitted
+- Drop entire metrics you don't want
+- Rewrite label values for normalization
+
+```yaml
+scrape_configs:
+  - job_name: my-app
+    metric_relabel_configs:
+      # Drop the pod label from every metric
+      - regex: pod
+        action: labeldrop
+
+      # Drop a specific high-cardinality metric entirely
+      - source_labels: [__name__]
+        regex: my_app_request_details
+        action: drop
+
+      # Normalize status_code to a class (200, 300, 400, 500)
+      - source_labels: [status_code]
+        regex: (\d)\d\d
+        target_label: status_code
+        replacement: ${1}xx
+```
+
+This is the **emergency stop** for bad labels. Use when you can't fix the app immediately.
+
+### 4. Recording Rules (query-time cardinality reduction)
+
+Pre-aggregate expensive series into a lower-cardinality recorded series. Stored at the same data point density but with far fewer series.
+
+```yaml
+groups:
+  - name: http-requests-aggregates
+    interval: 30s
+    rules:
+      # Drop pod/instance dimension; keep only service-level rollup
+      - record: service:http_requests:rate5m
+        expr: sum by (service, env, cluster, status_code) (rate(http_requests_total[5m]))
+```
+
+Queries that target the rollup are dramatically cheaper. The raw series still exist — recording rules don't reduce ingest cost (use Adaptive Metrics or `metric_relabel_configs` for that). They reduce query cost.
+
+---
+
+## Instrumentation Hygiene (for app developers)
+
+If the user is *writing* instrumentation code, these are the rules:
+
+| Rule | Why |
+|---|---|
+| Never use unbounded user input as a label value | `email`, `user_id`, `query string`, `error message` — they're the #1 cardinality bug |
+| Template HTTP paths before recording | `/users/{id}` not `/users/12345`. Most frameworks do this via routing metadata |
+| Bound error labels via small enums | `error_type="timeout"` not `error="connection to db-shard-7 timed out at 14:32:09"` |
+| Don't put `version` / `git_sha` / `build_id` on every metric | Use an info metric and join at query time |
+| Don't emit `pod` / `node` / `host` from code | Comes from scrape targets — duplicating creates collisions |
+| Avoid dynamically constructed label *names* (keys) | `metric{[user]=1}` cannot be bounded — use a fixed key |
+| Use histograms sparingly and trim labels first | 14× cardinality amplification |
+| Prefer exemplars over labels for trace correlation | Exemplars carry `trace_id` without inflating cardinality |
+
+### Exemplars (the escape hatch)
+
+Exemplars attach a `trace_id` (or any key-value pair) to specific samples *without* making it a label dimension. The ideal home for high-cardinality correlation data.
+
+Requires OpenMetrics format, Prometheus 2.26+, scrape config:
+```yaml
+scrape_configs:
+  - job_name: my-app
+    enable_protobuf_negotiation: true
+    # Or for text-format:
+    follow_redirects: true
+```
+
+And on the Prometheus server:
+```yaml
+storage:
+  exemplars:
+    max_exemplars: 100000
+```
+
+Use exemplars for:
+- `trace_id` correlation (Tempo, Jaeger)
+- `request_id` for specific debug lookups
+- Any sparse "useful when you need it" key
+
+Query exemplars via Grafana's exemplars-on-graph feature, not via PromQL aggregation.
+
+---
+
+## The 80/20 Rule
+
+The most impactful improvements almost always come from these five changes:
+
+1. **Drop unbounded labels at the app layer** — `path` (untemplated), `user_id`, `error_message`. Single biggest win.
+2. **Trim histogram label cardinality before anything else** — 14× amplification on every histogram.
+3. **Drop `pod` from application metrics** — keep `workload` instead. Eliminates churn, big stream-count reduction.
+4. **Use info metrics for `version` / `git_sha` / `image_tag`** — eliminates deploy-driven churn.
+5. **Set target labels via `relabel_configs`, not app code** — `env`, `cluster`, `team`, `service` should never be emitted by the application.
+
+Focus on these before anything else.
+
+---
+
+## Labels to Avoid — Quick Reference
+
+| Label | Why | Alternative |
+|---|---|---|
+| `user_id`, `customer_id` (large tenant base) | Unbounded | Exemplars; aggregate by `tenant_tier` |
+| `request_id`, `trace_id` | Unbounded | Exemplars |
+| `path` / `route` (raw URLs) | Unbounded | Template in code: `/users/:id` |
+| `error_message`, `query`, `sql` | Unbounded text | Bounded `error_type` enum |
+| `version`, `git_sha`, `image_tag` (on every metric) | Churn on every deploy | Info metric pattern |
+| `pod` (on app metrics) | Transient + high cardinality | `workload`; exemplars for pod-specific debug |
+| `uid` (K8s) | Unbounded; regenerates on restart | Drop entirely |
+| Application-emitted `instance`, `node`, `host` | Should come from scrape target | Drop via `metric_relabel_configs` |
+| Dynamically-named label keys | Cannot be bounded | Use fixed keys with bounded values |
+| Raw `status_code` on histograms | 14× amplification | Bucket to `status_class` (`2xx`, `4xx`, `5xx`) |
+
+---
+
+## When to Route Elsewhere
+
+- **"Reduce my Grafana Cloud bill"** → also engage `adaptive-metrics` skill (post-ingest aggregation rules)
+- **"Which metrics are driving my DPM?"** → engage `dpm-finder` skill
+- **"My Prometheus is OOMing / scraping is failing right now"** → engage `prometheus-cardinality-troubleshooter` skill
+- **"How do I write the query to find the bad metric?"** → engage `promql` skill
+- **"How do I configure relabel rules in Alloy?"** → engage `alloy` skill
+
+This skill's lane is **strategy and design**. Other skills own **diagnosis** and **operational remediation**.


### PR DESCRIPTION
## Summary

Adds two complementary skills to `grafana-cloud/` for Prometheus label hygiene — the Prometheus-side counterparts to `loki-label-analyzer`.

- **`prometheus-label-strategy`** — auditor/designer. Cardinality scoring, dual-impact rule, histogram bucket discipline (14× multiplier), info-metric pattern for `version` / `git_sha`, exemplars as the high-cardinality escape hatch, instrumentation hygiene rules, and the four source-side prevention levers (app code → `relabel_configs` → `metric_relabel_configs` → recording rules).
- **`prometheus-cardinality-troubleshooter`** — diagnostic for live fires. Symptom→cause table, `/api/v1/status/tsdb` triage, per-metric/per-label drill-downs, series-churn diagnosis, common-culprit gallery (histogram blowup, kube-state-metrics label explosion, untemplated paths, debug metrics in prod), and copy-paste emergency drop patterns for both Prometheus and Alloy.

## Scope boundaries

These skills cover **source-side prevention and diagnosis** only. Other skills retain their lanes:
- `adaptive-metrics` — post-ingest aggregation rules
- `dpm-finder` — DPM-specific analysis
- `promql` — query-side optimization
- `alloy` — collector configuration

Each skill explicitly routes to the right neighbor at the appropriate hand-off points.

## Files

- `skills/grafana-cloud/prometheus-label-strategy/SKILL.md` (new)
- `skills/grafana-cloud/prometheus-cardinality-troubleshooter/SKILL.md` (new)
- `README.md` — two new rows in the grafana-cloud table
- `.claude-plugin/`, `.agents-plugin/`, `.cursor-plugin/marketplace.json` — registered in grafana-cloud plugin (16 → 18 skills)

## Test plan

- [x] `scripts/lint-skills.sh` passes on both new skills (frontmatter, naming, body structure)
- [x] All three marketplace.json files parse cleanly (`jq` validates)
- [x] Skill count in all three marketplaces updated to 18
- [ ] CI lint-skills + validate workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)