### PR TITLE
fix(skills): stop recommending dropping unique-making labels (pod) at scrape time

### DIFF
--- a/skills/grafana-cloud/prometheus-cardinality-troubleshooter/SKILL.md
+++ b/skills/grafana-cloud/prometheus-cardinality-troubleshooter/SKILL.md
@@ -19,6 +19,24 @@ This skill is **diagnostic and operational**. For schema design and prevention, 
 
 ---
 
+## Before You Remediate: The One Rule
+
+Under pressure, the tempting move is to `labeldrop` the high-cardinality label at scrape time. **Do not.** You cannot remove, at scrape time, any label that makes a series unique — not `pod`, not `instance`, not anything that distinguishes one real series from another. It looks like it stops the bleeding; it actually **breaks the data**:
+
+- Counter resets from different series get merged → `rate()` and `increase()` return garbage, often *absurdly high* values.
+- Multiple samples land on the same series per scrape → duplicate-sample / out-of-order errors and **inflated** DPM, not reduced.
+- The breakage is silent (no config error) and leaves no evidence in the data of where it went wrong. Weeks later someone asks "why is my DPM so high / why is `rate()` absurd?" and there's nothing to point to.
+
+The only safe remediations are:
+
+1. **Drop an *entire* unwanted metric** (`action: drop` on `__name__`) — you're discarding the whole metric, not merging distinct series.
+2. **Fix the source** — stop the application emitting the bad label (the real fix for unbounded `path`, `user_id`, etc.).
+3. **Adaptive Metrics** — for structural cardinality on series you can't fix at the source. It aggregates *correctly* (counter-reset-aware, audited, reversible). This is the right way to reduce the cost of a label like `pod`. Route to `adaptive-metrics`.
+
+Everywhere below that says "drop a label," read it through this rule: drop whole metrics, fix the source, or use Adaptive Metrics — never `labeldrop` a distinguishing label.
+
+---
+
 ## Symptom → Likely Cause
 
 | Symptom | Likely Cause | First Action |
@@ -92,7 +110,7 @@ curl -s -u "<user>:<token>" \
 ```
 
 **Heuristics**:
-- A histogram (`_bucket`) at the top is almost always the answer — those have a 14× multiplier (bucket count + 3). The fix is usually **trimming labels on the underlying histogram**, not the buckets themselves.
+- A histogram (`_bucket`) at the top is almost always the answer — those have a 14× multiplier (bucket count + 3). The fix is usually **reducing the labels on the underlying histogram at the source** (in instrumentation code), not stripping them at scrape and not touching the buckets themselves.
 - A metric in the top 5 you don't recognize → grep the codebase for it; it's likely a new feature flag or a debug metric that shipped to prod
 - The same metric showing up under multiple variants (`_total`, `_count`, `_sum`) — that's a histogram or summary, count all variants together for the true impact
 
@@ -233,7 +251,7 @@ Restarting Prometheus drops churned series but is not a fix. The fix is at the s
 **Tell**: `*_bucket` metric at the top of `seriesCountByMetricName`. Multiplier ≈ 14×.
 
 **Fix**:
-1. First, **reduce labels on the histogram** — every label removed saves 14× series. Trim `path`, `method`, or `status_code` before touching bucket count.
+1. First, **reduce labels on the histogram at the source** — every label removed saves 14× series. Trim `path`, `method`, or `status_code` in the instrumentation code (don't `labeldrop` them at scrape — that merges distinct histograms and corrupts the buckets). For series already in Grafana Cloud you can't change, aggregate them with Adaptive Metrics.
 2. Then, reduce bucket count if appropriate (custom buckets vs. defaults).
 3. For high-resolution latency tracking, consider **native histograms** (Prometheus 2.40+) — single sparse series replaces the bucket family.
 
@@ -253,23 +271,18 @@ Restarting Prometheus drops churned series but is not a fix. The fix is at the s
 
 **Tell**: `http_requests_total` (or framework equivalent) grew 10×+ overnight. `topk(20, count by (path) (http_requests_total))` shows hundreds of `/users/123456`-style values.
 
-**Fix**: route the user to `prometheus-label-strategy` for the long-term fix (template paths in code). For the immediate stop:
+**Fix**: the real fix is to **template the path in application code** (`/users/:id`) — route the user to `prometheus-label-strategy`. For series already in Grafana Cloud, **Adaptive Metrics** can aggregate `path` away correctly — route to `adaptive-metrics`.
+
+Do **not** "normalize" `path` with a relabel `replacement` rule — collapsing `/users/123`, `/users/456`, … into one `/users/:id` value at scrape merges distinct series and produces duplicate-sample errors and broken `rate()`. The merge has to happen at the source (templating) or post-ingest (Adaptive Metrics), never at scrape.
+
+If you must stop a production fire *right now* and templating isn't deployable yet, the only safe scrape-time action is to drop the **entire** offending metric (you lose it completely until the code fix lands — a deliberate trade, not a silent corruption):
 
 ```yaml
-# In Prometheus scrape config — emergency drop
+# Emergency: drop the whole metric until the source is templated
 metric_relabel_configs:
-  - source_labels: [__name__, path]
-    regex: http_requests_total;/users/\d+
+  - source_labels: [__name__]
+    regex: http_requests_total
     action: drop
-```
-
-Or normalize via relabel:
-```yaml
-metric_relabel_configs:
-  - source_labels: [path]
-    regex: /users/\d+
-    target_label: path
-    replacement: /users/:id
 ```
 
 ### Application emitting a debug metric in prod
@@ -286,18 +299,23 @@ metric_relabel_configs:
 
 Open a ticket against the team to remove it from the code.
 
-### Broken relabel rule allowing app-emitted target labels
+### App-emitted labels colliding with target labels
 
-**Tell**: Series count for one job is several × what it should be. Looking at one series, you see both an app-emitted `instance=...` AND the target `instance=...` collided into something weird.
+**Tell**: Series count for one job is several × what it should be. Looking at one series, you see both an app-emitted `instance=...` AND the target `instance=...` collided into something weird (Prometheus renames the conflicting one to `exported_instance`).
 
-**Fix**: ensure your `metric_relabel_configs` drops the labels that should come only from targets:
+**Fix**: the right fix is **in the application** — stop emitting `instance`/`node`/`host` from code; they belong to the scrape target. Confirm `honor_labels` is `false` (the default) so the target labels win.
+
+If you need a scrape-time stopgap, you may remove a label *only* where it **exactly duplicates** a target label — that's the one safe `labeldrop`, because the target label still provides uniqueness. Scope it tightly to the duplicated names and **never include `pod`** (or any other label that is the source of uniqueness):
+
 ```yaml
+# Stopgap ONLY for app-emitted duplicates of target labels.
+# Drops the `exported_*` collisions — NOT pod, which makes K8s series unique.
 metric_relabel_configs:
-  - regex: (instance|pod|node|host|job)
+  - regex: exported_(instance|node|host)
     action: labeldrop
 ```
 
-Then the target labels from `relabel_configs` apply cleanly.
+Then the target labels from `relabel_configs` apply cleanly. Prefer fixing the app.
 
 ### Federation amplifying cardinality
 
@@ -322,68 +340,53 @@ Then the target labels from `relabel_configs` apply cleanly.
 Cardinality fire confirmed
 │
 ├── Need to stop the bleeding NOW (production OOM, ingest 429s)
-│   └── Apply emergency drop via metric_relabel_configs at scrape config
+│   └── Drop the ENTIRE offending metric via metric_relabel_configs (action: drop on __name__)
 │       (also applies to Alloy/Agent — same syntax)
+│       Do NOT labeldrop a distinguishing label — it breaks the data, see "The One Rule".
 │       Then schedule the proper fix.
 │
 ├── It's a Grafana Cloud Active Series bill issue, not a perf issue
 │   ├── Cardinality is structural and you can't fix the app
-│   │   └── Route to `adaptive-metrics` skill (post-ingest aggregation rules)
+│   │   └── Route to `adaptive-metrics` skill (post-ingest aggregation rules — the safe way)
 │   └── You want metric-by-metric DPM breakdown
 │       └── Route to `dpm-finder` skill
 │
 ├── It's a fixable application bug (unbounded label, debug metric in prod)
-│   ├── Short-term: metric_relabel_configs drop at scrape
+│   ├── Short-term: drop the whole metric at scrape, OR aggregate via Adaptive Metrics
 │   └── Long-term: fix in code; route to `prometheus-label-strategy` for design guidance
 │
 ├── It's histogram cardinality
-│   ├── Trim labels on the underlying histogram (14× win per label)
+│   ├── Reduce labels on the underlying histogram AT THE SOURCE (14× win per label)
 │   ├── Reduce bucket count if appropriate
 │   └── Consider native histograms for high-resolution latency
 │
 └── It's churn (deploy-driven)
-    ├── Remove `pod`, `version`, `git_sha` from application metrics
-    ├── Use info-metric pattern for `version` (route to `prometheus-label-strategy`)
-    └── Verify K8s SD relabel rules aren't carrying `uid` or other ephemeral fields
+    ├── Stop EMITTING `version`/`git_sha`/`instance` from app code (use info-metric for version)
+    ├── Keep `pod` — never drop it; if pod-level series are too costly, use Adaptive Metrics
+    └── Verify K8s SD relabel rules aren't mapping in `uid` or other ephemeral fields
 ```
 
 ---
 
 ## Emergency Drop Patterns (copy-paste ready)
 
+These are the **safe** scrape-time emergency actions: dropping an *entire* unwanted metric. They do not merge distinct series, so they don't corrupt the data.
+
+> ⚠️ There is intentionally **no `labeldrop` of a distinguishing label** and **no value-normalizing relabel** here. Both merge distinct series and break `rate()`/DPM (see [The One Rule](#before-you-remediate-the-one-rule)). To reduce cardinality *without* dropping the whole metric, fix the source or use **Adaptive Metrics** (route to `adaptive-metrics`). The only safe `labeldrop` is removing a label that *exactly duplicates* a target label (e.g. `exported_instance`) — see [App-emitted labels colliding with target labels](#app-emitted-labels-colliding-with-target-labels).
+
 For Prometheus `scrape_configs`:
 
 ```yaml
 metric_relabel_configs:
-  # Drop a specific bad metric
+  # Drop a specific bad metric entirely
   - source_labels: [__name__]
     regex: bad_metric_name
     action: drop
 
-  # Drop a high-cardinality label from all metrics
-  - regex: bad_label_name
-    action: labeldrop
-
-  # Drop all labels matching a prefix (e.g., debug_*)
-  - regex: debug_.*
-    action: labeldrop
-
-  # Drop a metric only when a specific label has unbounded values
-  - source_labels: [__name__, path]
-    regex: http_requests_total;/users/\d+
+  # Drop a set of debug/temporary metrics by name prefix
+  - source_labels: [__name__]
+    regex: debug_.*
     action: drop
-
-  # Aggregate path patterns to a template (replace the value)
-  - source_labels: [path]
-    regex: /users/\d+
-    target_label: path
-    replacement: /users/:id
-
-  # Aggregate status codes to classes
-  - source_labels: [status_code]
-    regex: (\d)\d\d
-    target_label: status_code
-    replacement: ${1}xx
 ```
 
 For Grafana Alloy (`prometheus.relabel` component):
@@ -397,15 +400,10 @@ prometheus.relabel "drop_bad_metric" {
     regex = "bad_metric_name"
     action = "drop"
   }
-
-  rule {
-    regex = "bad_label_name"
-    action = "labeldrop"
-  }
 }
 ```
 
-**Always test in staging first.** A misconfigured `labeldrop` regex can wipe critical labels across every metric.
+**Always test in staging first**, and prefer fixing the source or using Adaptive Metrics over any scrape-time drop.
 
 ---
 

--- a/skills/grafana-cloud/prometheus-label-strategy/SKILL.md
+++ b/skills/grafana-cloud/prometheus-label-strategy/SKILL.md
@@ -2,20 +2,43 @@
 name: prometheus-label-strategy
 license: Apache-2.0
 description: >
-  Expert evaluator for Prometheus label strategy. Audits, designs, and improves label
-  schemas using cardinality scoring, access-pattern alignment, static vs. dynamic label
-  rules, histogram bucket discipline, instrumentation hygiene, and source-side prevention
-  via relabel_config / metric_relabel_configs. Use when the user asks to evaluate, audit,
-  design, or improve Prometheus labels — or asks how to prevent high cardinality at the
-  source. For post-ingest aggregation, see the adaptive-metrics skill. For "why is my
-  Prometheus slow / expensive right now" triage, see prometheus-cardinality-troubleshooter.
+  Expert evaluator for Prometheus label strategy on Grafana Cloud. Audits, designs, and
+  improves label schemas using cardinality scoring, access-pattern alignment, static vs.
+  dynamic label rules, histogram bucket discipline, and instrumentation hygiene. Prevents
+  high cardinality at the source — in application code and scrape target labels — without
+  dropping labels that make series unique (which breaks the data). For reducing the cost of
+  series already in Grafana Cloud, routes to the adaptive-metrics skill. Use when the user
+  asks to evaluate, audit, design, or improve Prometheus labels — or asks how to prevent
+  high cardinality at the source. For "why is my Prometheus slow / expensive right now"
+  triage, see prometheus-cardinality-troubleshooter.
 ---
 
 # Prometheus Label Strategy Evaluator
 
 You are an expert in Prometheus label strategy. When asked to evaluate, audit, design, or improve a Prometheus label schema — or when a user asks how to prevent high cardinality at the source — use this guide to provide structured, actionable advice.
 
-This skill is about **preventing bad labels at ingest** (instrumentation, scrape configuration, relabeling). For post-ingest cost reduction via aggregation rules, route the user to the `adaptive-metrics` skill. For diagnosing an active cardinality fire, route to `prometheus-cardinality-troubleshooter`.
+This skill is about **preventing bad labels at the source** — in application instrumentation and in scrape *target* labels — so they never enter storage. It is **not** about stripping labels off metrics after they've been emitted: removing a label that makes a series unique at scrape time silently breaks the data (see [The One Rule](#the-one-rule-never-drop-a-label-that-makes-a-series-unique) below). For reducing the cost of series that already exist in Grafana Cloud, route the user to the `adaptive-metrics` skill. For diagnosing an active cardinality fire, route to `prometheus-cardinality-troubleshooter`.
+
+---
+
+## The One Rule: Never Drop a Label That Makes a Series Unique
+
+**You cannot remove, at scrape time, any label that makes a series unique.** Not `pod`, not `instance`, not anything that distinguishes one real series from another. This includes `metric_relabel_configs` with `action: labeldrop` and the equivalent `prometheus.relabel` rules in Alloy.
+
+It looks like a cardinality win. It is not — it **breaks the data**, silently and permanently:
+
+- **Counter resets get mixed together.** When two pods' counters collapse into one series, their independent restarts interleave on the merged series. `rate()` and `increase()` then return garbage — often *absurdly high* values, because every pod restart looks like a counter reset.
+- **DPM inflates instead of dropping.** Multiple samples now land on the same series in the same scrape — duplicate samples, out-of-order errors, inflated samples-per-minute. People come back weeks later asking "why is my DPM so high?" or "why is `rate()` returning absurd numbers?" — and there is **no evidence left in the data** of where it broke.
+- **The aggregation is wrong, not just coarse.** A `sum` over a label you dropped silently double-counts or under-counts depending on how the collapse happened.
+
+The trap is that none of this errors at config time. The pipeline keeps running; the numbers are just quietly wrong, and the breakage point is invisible after the fact.
+
+**The right tools, in order:**
+
+1. **Don't emit the bad label in the first place** — fix the application code. This is the only place a label can be *removed* without consequence, because the series was never unique on it to begin with.
+2. **For series already flowing into Grafana Cloud that you can't fix at the source → Adaptive Metrics.** This is exactly what it is for: it aggregates series *correctly* — counter-reset-aware, with a recorded audit trail, and reversible — instead of blindly stripping labels. Route the user to the `adaptive-metrics` skill.
+
+`metric_relabel_configs` has a couple of narrow, safe uses (dropping an *entire* unwanted metric; removing a label that *exactly duplicates* a target label) — covered in [Source-Side Prevention](#4-metric_relabel_configs-narrow-safe-uses-only) — but **reducing cardinality by dropping a distinguishing label is never one of them.**
 
 ---
 
@@ -49,7 +72,7 @@ When auditing a label set, assess each label against these criteria.
 | `namespace` (K8s) | Tens–low hundreds | ✅ Acceptable |
 | `service`, `workload`, `container` | Tens–hundreds | ✅ Acceptable |
 | `instance` (host:port) | Hundreds–low thousands | ⚠️ Evaluate — fine on per-instance metrics, risky on aggregated ones |
-| `pod` (K8s) | Thousands + transient = high churn | ❌ Drop at scrape unless required |
+| `pod` (K8s) | Thousands + transient = high churn | ⚠️ Required for K8s monitoring and series uniqueness — keep it. If `pod`-level series are too expensive, reduce them with Adaptive Metrics; **never** drop at scrape |
 | `path` / `route` (HTTP) | Bounded if templated; unbounded if raw URLs | ⚠️ Only with templated values (`/users/:id`) |
 | `version`, `image_tag`, `git_sha` | Grows on every deploy → churn | ⚠️ Use sparingly; consider info-metric pattern |
 | `user_id`, `request_id`, `trace_id` | Unbounded | ❌ Never as label — use exemplars |
@@ -119,7 +142,7 @@ When auditing a label set, produce a report in this structure:
 | Metric Family | Label | Cardinality | Used in Queries? | Verdict | Action |
 |---|---|---|---|---|---|
 | http_requests_total | path | Unbounded (raw URLs) | Sometimes | ❌ Remove | Template in code: `/users/:id` not `/users/12345` |
-| http_requests_total | pod | High + churn | Rarely | ❌ Drop via metric_relabel_configs | Already in target metadata |
+| http_requests_total | pod | High + churn | Rarely | ⚠️ Keep — makes the series unique | If too expensive, aggregate away with Adaptive Metrics; query by `workload` for the common case |
 
 ### Histogram-Specific Findings
 [Highlight any histograms with high label cardinality — these are 14×+ amplified]
@@ -133,9 +156,9 @@ When auditing a label set, produce a report in this structure:
 [Final recommended labels per metric family]
 
 ### Implementation Plan
-1. [Code changes — instrumentation hygiene]
-2. [Scrape config changes — relabel_configs]
-3. [Drop-at-scrape changes — metric_relabel_configs]
+1. [Code changes — instrumentation hygiene: stop emitting bad labels at the source]
+2. [Scrape target labels — relabel_configs (additive: env, cluster, team, workload)]
+3. [Post-ingest cost reduction on series you can't fix at the source — Adaptive Metrics]
 4. [Recording rules to materialize useful aggregates]
 ```
 
@@ -167,42 +190,36 @@ These should **NOT** be re-emitted by the application. If the app emits a `clust
 |---|---|---|
 | `namespace` | Pod metadata | Always keep |
 | `container` | Pod spec | Low cardinality, useful for multi-container pods |
-| `workload` | Derived: `{controller_kind}/{controller_name}` | **Strongly preferred over `pod`** — static, predictable |
+| `workload` | Derived: `{controller_kind}/{controller_name}` | Add as a stable aggregation key *alongside* `pod` — static, predictable. It's an addition, not a replacement: don't use it as an excuse to drop `pod` |
 | `service` | K8s Service | If scraping via Service |
 
-### Labels to AVOID by Default in Kubernetes
+### Handling the `pod` Label
 
-**`pod` label** ⚠️
-- Highly transient: rolls every deploy and on every restart
-- High cardinality: 100 pods × N metrics = N × 100 series, but on rollouts you carry both old and new pods until they age out
-- Almost never the right query dimension — users want *workload*, not *pod instance*
-- **Solution**: Keep `workload` as a label; drop `pod` via `metric_relabel_configs`; use exemplars or kube-state-metrics for pod-specific lookups
+`pod` is high-cardinality and transient — it rolls on every deploy and restart, so it dominates churn and series count. But it is also a label that **makes K8s series unique**, and Kubernetes monitoring (per-pod resource attribution, kube-state-metrics joins) depends on it. [The One Rule](#the-one-rule-never-drop-a-label-that-makes-a-series-unique) applies: **do not drop `pod` at scrape time.** Collapsing pods into one series mixes their counter resets and breaks `rate()`.
 
-```yaml
-# Drop the pod label from application metrics at scrape time
-metric_relabel_configs:
-  - regex: pod
-    action: labeldrop
-```
+Instead:
+- **Add `workload`** (`{controller_kind}/{controller_name}`) as a *target* label via `relabel_configs`, so dashboards and alerts can aggregate on the stable workload identity (`sum by (workload)`) without touching `pod`. This is additive — it removes nothing.
+- **Don't emit `pod` from application code** — let it come from Kubernetes service discovery, so there is exactly one source of truth (see below).
+- **If `pod`-level series are genuinely too expensive in Grafana Cloud**, reduce them with **Adaptive Metrics**, which aggregates `pod` away *correctly* (post-ingest, counter-reset-aware, reversible) rather than corrupting the raw data at scrape. Route to the `adaptive-metrics` skill.
 
-**`uid` label** ❌
-- Completely unbounded (regenerates on every pod recreation)
-- No legitimate query use — kept only by accident in default kubernetes_sd configs
+### Don't Map Ephemeral Fields into Labels in the First Place
 
-**Application-emitted `instance` / `pod` / `node`** ❌
-- These should come from target labels, not from the app code
-- Drop them at scrape with `metric_relabel_configs` or fix in code
+**`uid`** regenerates on every pod recreation and has no legitimate query use. The fix is to **never map it into a label** — leave it out of your `relabel_configs`. (It isn't in default `kubernetes_sd_configs` output unless you explicitly target it.) Don't try to `labeldrop` it after the fact — by then it's already distinguishing series, and removing it breaks the data exactly like dropping any other unique label.
 
-**kube-state-metrics annotation / label propagation** ⚠️
+### One Source of Truth for Target Identity
+
+`instance`, `pod`, `node`, and `host` should come from **scrape target labels**, not from application code. If the app *also* emits its own `instance`/`node`, you get duplicates and `honor_labels` collisions. The fix is **in the application** — stop emitting them — not a scrape-time `labeldrop`. (Removing a label that *exactly duplicates* a target label is the one narrow exception; see [metric_relabel_configs](#4-metric_relabel_configs-narrow-safe-uses-only).)
+
+### kube-state-metrics label propagation ⚠️
 - `kube_pod_labels{label_app_kubernetes_io_*=...}` can carry dozens of metadata labels
 - Each unique pod label combination is a new series
-- Use kube-state-metrics' `--metric-labels-allowlist` to restrict to the labels you actually query on
+- Restrict at the source with kube-state-metrics' `--metric-labels-allowlist` — this controls what is *ever emitted*, so it's prevention, not destructive after-the-fact dropping
 
 ---
 
 ## Source-Side Prevention: Where to Fix What
 
-There are four levers, in **order of preference**:
+There are five levers, in **order of preference**:
 
 ### 1. Fix in the Application (best)
 
@@ -241,36 +258,37 @@ scrape_configs:
         action: keep
 ```
 
-### 3. `metric_relabel_configs` (scrape-time relabeling)
+### 3. Adaptive Metrics (Grafana Cloud — post-ingest, the safe way to reduce cardinality)
 
-Runs *after* the scrape, *before* storage. Used to:
-- Drop high-cardinality labels the app shouldn't have emitted
-- Drop entire metrics you don't want
-- Rewrite label values for normalization
+When the cardinality is structural and you *can't* fix it at the source — the label legitimately exists and makes series unique, you just don't need every value at full resolution — **Adaptive Metrics is the correct tool, and the only safe way to reduce the cost of series that already exist.**
 
-```yaml
-scrape_configs:
-  - job_name: my-app
-    metric_relabel_configs:
-      # Drop the pod label from every metric
-      - regex: pod
-        action: labeldrop
+It works *after* ingest, as aggregation rules applied in Grafana Cloud. Crucially, it aggregates series **correctly**:
+- It handles counter resets properly, so `rate()` and `increase()` stay accurate.
+- It records what was aggregated, so there's an audit trail — you can answer "why did this change?" later.
+- It's reversible: drop a rule and the full-resolution series come back.
 
-      # Drop a specific high-cardinality metric entirely
-      - source_labels: [__name__]
-        regex: my_app_request_details
-        action: drop
+This is the difference between "the data is now cheaper" (Adaptive Metrics) and "the data is now wrong" (`labeldrop` at scrape). Route the user to the `adaptive-metrics` skill for rule design.
 
-      # Normalize status_code to a class (200, 300, 400, 500)
-      - source_labels: [status_code]
-        regex: (\d)\d\d
-        target_label: status_code
-        replacement: ${1}xx
-```
+### 4. `metric_relabel_configs` (narrow, safe uses only)
 
-This is the **emergency stop** for bad labels. Use when you can't fix the app immediately.
+Runs *after* the scrape, *before* storage.
 
-### 4. Recording Rules (query-time cardinality reduction)
+> ⚠️ **Do not use `metric_relabel_configs` (or Alloy `prometheus.relabel`) to drop a label that distinguishes series — `pod`, `instance`, `user_id`, `path`, anything.** See [The One Rule](#the-one-rule-never-drop-a-label-that-makes-a-series-unique). It looks like a cardinality fix and silently breaks `rate()`, inflates DPM, and corrupts aggregations. Use the application code (lever 1) or Adaptive Metrics (lever 3) instead. The same caution applies to *normalizing* a label value (e.g. collapsing `status_code` to `2xx`) at scrape — it merges distinct series and produces duplicate-sample errors; do that in code or via Adaptive Metrics, never here.
+
+The genuinely safe uses are:
+
+- **Drop an entire metric you never want stored** — you're discarding the whole metric, not collapsing distinct series into one:
+  ```yaml
+  metric_relabel_configs:
+    - source_labels: [__name__]
+      regex: my_app_request_details
+      action: drop
+  ```
+- **Remove a label that *exactly duplicates* a target label.** If the app emits its own `cluster`/`instance` that already comes from the scrape target, the target label still provides uniqueness, so removing the duplicate breaks nothing. Prefer fixing the app, but this is a safe stopgap.
+
+That's the whole list. If you're reaching for `metric_relabel_configs` to bring down a series count, you almost certainly want Adaptive Metrics instead.
+
+### 5. Recording Rules (query-time cardinality reduction)
 
 Pre-aggregate expensive series into a lower-cardinality recorded series. Stored at the same data point density but with far fewer series.
 
@@ -284,7 +302,7 @@ groups:
         expr: sum by (service, env, cluster, status_code) (rate(http_requests_total[5m]))
 ```
 
-Queries that target the rollup are dramatically cheaper. The raw series still exist — recording rules don't reduce ingest cost (use Adaptive Metrics or `metric_relabel_configs` for that). They reduce query cost.
+Queries that target the rollup are dramatically cheaper. The raw series still exist — recording rules don't reduce ingest cost (use **Adaptive Metrics** for that — *not* a scrape-time `labeldrop`). They reduce query cost.
 
 ---
 
@@ -338,7 +356,7 @@ The most impactful improvements almost always come from these five changes:
 
 1. **Drop unbounded labels at the app layer** — `path` (untemplated), `user_id`, `error_message`. Single biggest win.
 2. **Trim histogram label cardinality before anything else** — 14× amplification on every histogram.
-3. **Drop `pod` from application metrics** — keep `workload` instead. Eliminates churn, big stream-count reduction.
+3. **Don't emit `pod`/`instance`/`node` from application code** — let them come from scrape targets, and add a stable `workload` target label to aggregate on. (Never *drop* the real `pod` at scrape to cut cardinality — if `pod`-level series are too expensive, use Adaptive Metrics.)
 4. **Use info metrics for `version` / `git_sha` / `image_tag`** — eliminates deploy-driven churn.
 5. **Set target labels via `relabel_configs`, not app code** — `env`, `cluster`, `team`, `service` should never be emitted by the application.
 
@@ -355,9 +373,9 @@ Focus on these before anything else.
 | `path` / `route` (raw URLs) | Unbounded | Template in code: `/users/:id` |
 | `error_message`, `query`, `sql` | Unbounded text | Bounded `error_type` enum |
 | `version`, `git_sha`, `image_tag` (on every metric) | Churn on every deploy | Info metric pattern |
-| `pod` (on app metrics) | Transient + high cardinality | `workload`; exemplars for pod-specific debug |
-| `uid` (K8s) | Unbounded; regenerates on restart | Drop entirely |
-| Application-emitted `instance`, `node`, `host` | Should come from scrape target | Drop via `metric_relabel_configs` |
+| App-emitted `pod` (duplicating SD) | Should come from K8s service discovery, not code | Stop emitting it in code; keep the discovered `pod`. Never drop the real `pod` to cut cardinality — use Adaptive Metrics |
+| `uid` (K8s) | Unbounded; regenerates on restart | Never map it into a label in the first place (leave it out of `relabel_configs`) |
+| Application-emitted `instance`, `node`, `host` | Should come from scrape target | Stop emitting in code (removing an *exact* target-label duplicate at scrape is the only safe drop) |
 | Dynamically-named label keys | Cannot be bounded | Use fixed keys with bounded values |
 | Raw `status_code` on histograms | 14× amplification | Bucket to `status_class` (`2xx`, `4xx`, `5xx`) |
 
@@ -365,7 +383,7 @@ Focus on these before anything else.
 
 ## When to Route Elsewhere
 
-- **"Reduce my Grafana Cloud bill"** → also engage `adaptive-metrics` skill (post-ingest aggregation rules)
+- **"Reduce my Grafana Cloud bill"** / **"reduce cardinality on series already ingested"** → engage `adaptive-metrics` skill (post-ingest aggregation rules — the safe, counter-reset-aware way; never `labeldrop` distinguishing labels at scrape)
 - **"Which metrics are driving my DPM?"** → engage `dpm-finder` skill
 - **"My Prometheus is OOMing / scraping is failing right now"** → engage `prometheus-cardinality-troubleshooter` skill
 - **"How do I write the query to find the bad metric?"** → engage `promql` skill


### PR DESCRIPTION
## Why

Review feedback on the Prometheus label skills: **you cannot remove, at scrape time, any label that makes a series unique** — not `pod`, not anything that distinguishes one real series from another. The skills were recommending dropping `pod` via `metric_relabel_configs` / `labeldrop`, which silently **breaks the data**:

- Counter resets from different series merge → `rate()`/`increase()` return absurdly high values
- Duplicate samples land on the merged series → DPM *inflates* instead of dropping, with out-of-order errors
- No config-time error and no evidence left in the data of where it broke — people come back weeks later asking "why is my DPM so high / why is `rate()` absurd?"

The correct tool for reducing the cost of series that already exist in Grafana Cloud is **Adaptive Metrics**, which aggregates correctly (counter-reset-aware, audited, reversible). These skills are focused on Grafana Cloud.

## What changed

**`prometheus-label-strategy`**
- Added a prominent **"The One Rule: Never Drop a Label That Makes a Series Unique"** section
- Removed every recommendation to drop `pod` (cardinality table, audit example, 80/20 rule, quick-reference, implementation plan)
- Reframed Kubernetes guidance: keep `pod`; add `workload` as an *additive* aggregation key; don't map ephemeral fields like `uid` into labels in the first place
- Inserted **Adaptive Metrics** as the safe post-ingest lever; restricted `metric_relabel_configs` to its genuinely safe uses (drop a whole metric; remove an exact target-label duplicate) and removed the value-normalize example (it merges series)

**`prometheus-cardinality-troubleshooter`**
- Added **"Before You Remediate: The One Rule"** up top
- Safe emergency action is now dropping the *entire* offending metric; removed `labeldrop` and value-normalize patterns from the emergency snippets (Prometheus + Alloy)
- Reworked the app/target label-collision fix to a tightly-scoped `exported_*` stopgap that explicitly excludes `pod`
- Routes structural cardinality to Adaptive Metrics; keeps `pod` in churn guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)