### PR TITLE
ci(quality): add tesslio/skill-review workflow for LLM-judged PR review

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -8,11 +8,19 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  # The action posts/updates a PR comment via octokit.rest.issues.createComment,
+  # which is gated on `issues: write` (not `pull-requests: write`) since GitHub
+  # treats PR comments as issue comments under the hood.
+  issues: write
+  pull-requests: read
 
 jobs:
   skill-review:
     runs-on: ubuntu-latest
+    # Fork PRs receive a read-only GITHUB_TOKEN, so the comment-posting step
+    # cannot succeed there. Skip the job rather than fail; the review can run
+    # locally via scripts/review-all-skills.sh on the contributor's branch.
+    if: github.event.pull_request.head.repo.fork != true
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -27,3 +35,9 @@ jobs:
           # Report only at first — flip to a numeric threshold (e.g. 70) once we
           # have a baseline of real scores against this repo's skills.
           fail-threshold: 0
+
+  fork-pr-notice:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == true
+    steps:
+      - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only). Run the review locally with scripts/review-all-skills.sh and paste results into the PR."

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -14,8 +14,7 @@ jobs:
   skill-review:
     runs-on: ubuntu-latest
     # Fork PRs receive a read-only GITHUB_TOKEN, so the comment-posting step
-    # cannot succeed there. Skip the job rather than fail; the review can run
-    # locally via scripts/review-all-skills.sh on the contributor's branch.
+    # cannot succeed there. Skip the job rather than fail.
     if: github.event.pull_request.head.repo.fork != true
     permissions:
       contents: read
@@ -44,4 +43,4 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     permissions: {}
     steps:
-      - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only). Run the review locally with scripts/review-all-skills.sh and paste results into the PR."
+      - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only). The review will run automatically once the PR is merged."

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -18,14 +18,25 @@ jobs:
     if: github.event.pull_request.head.repo.fork != true
     permissions:
       contents: read
-      # The action posts/updates a PR comment via octokit.rest.issues.createComment,
-      # which is gated on `issues: write` (not `pull-requests: write`) since GitHub
-      # treats PR comments as issue comments under the hood.
+      # id-token: write — required by grafana/shared-workflows for Vault OIDC.
+      id-token: write
+      # issues: write — the action posts/updates a PR comment via
+      # octokit.rest.issues.createComment (PR comments are issue comments
+      # under the hood). pull-requests: read is enough to list changed files.
       issues: write
       pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get Tessl token from Vault
+        # Tessl API token (from https://tessl.io workspace settings) maintained
+        # in Grafana's dev Vault.
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          vault_instance: dev
+          repo_secrets: |
+            TESSL_TOKEN=tessl-token:token
 
       # tesslio/skill-review has no tagged releases as of 2026-06-04, so we pin to
       # the current HEAD commit on main per Grafana's GitHub Actions guidelines.
@@ -33,6 +44,11 @@ jobs:
       #   gh api repos/tesslio/skill-review/commits/main --jq .sha
       - name: Run Tessl Skill Review
         uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main @ 2026-03-27
+        env:
+          # The action's internal setup-tessl@v1 path is unauthenticated, but
+          # we forward TESSL_TOKEN so when @v2 lands (token-required) the
+          # workflow keeps working without a code change.
+          TESSL_TOKEN: ${{ env.TESSL_TOKEN }}
         with:
           # Report only at first — flip to a numeric threshold (e.g. 70) once we
           # have a baseline of real scores against this repo's skills.

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -6,13 +6,9 @@ on:
     paths:
       - 'skills/**/SKILL.md'
 
-permissions:
-  contents: read
-  # The action posts/updates a PR comment via octokit.rest.issues.createComment,
-  # which is gated on `issues: write` (not `pull-requests: write`) since GitHub
-  # treats PR comments as issue comments under the hood.
-  issues: write
-  pull-requests: read
+# Workflow defaults to no permissions; each job grants only what it needs
+# (avoids zizmor/excessive-permissions on the workflow-wide block).
+permissions: {}
 
 jobs:
   skill-review:
@@ -21,6 +17,13 @@ jobs:
     # cannot succeed there. Skip the job rather than fail; the review can run
     # locally via scripts/review-all-skills.sh on the contributor's branch.
     if: github.event.pull_request.head.repo.fork != true
+    permissions:
+      contents: read
+      # The action posts/updates a PR comment via octokit.rest.issues.createComment,
+      # which is gated on `issues: write` (not `pull-requests: write`) since GitHub
+      # treats PR comments as issue comments under the hood.
+      issues: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -39,5 +42,6 @@ jobs:
   fork-pr-notice:
     runs-on: ubuntu-latest
     if: github.event.pull_request.head.repo.fork == true
+    permissions: {}
     steps:
       - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only). Run the review locally with scripts/review-all-skills.sh and paste results into the PR."

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,29 @@
+name: Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'skills/**/SKILL.md'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  skill-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # tesslio/skill-review has no tagged releases as of 2026-06-04, so we pin to
+      # the current HEAD commit on main per Grafana's GitHub Actions guidelines.
+      # Refresh this SHA on review by running:
+      #   gh api repos/tesslio/skill-review/commits/main --jq .sha
+      - name: Run Tessl Skill Review
+        uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main @ 2026-03-27
+        with:
+          # Report only at first — flip to a numeric threshold (e.g. 70) once we
+          # have a baseline of real scores against this repo's skills.
+          fail-threshold: 0

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -43,4 +43,4 @@ jobs:
     if: github.event.pull_request.head.repo.fork == true
     permissions: {}
     steps:
-      - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only). The review will run automatically once the PR is merged."
+      - run: echo "::notice::Skipping Tessl Skill Review on fork PR (GITHUB_TOKEN is read-only and cannot post review comments). A maintainer can run the review on a same-repo branch if needed."


### PR DESCRIPTION
## Summary

Adds [`tesslio/skill-review`](https://github.com/tesslio/skill-review) as a PR-time quality check for skill content. The action auto-detects changed `SKILL.md` files, scores them with an LLM-as-judge rubric, and posts a single PR comment with per-dimension scores plus suggestions.

This is **PR 3 of 3** introducing a layered QA pipeline for `grafana/skills`:
- [PR #29](https://github.com/grafana/skills/pull/29) — structural + supply-chain lint
- [PR #30](https://github.com/grafana/skills/pull/30) — security scan ([`snyk/agent-scan`](https://github.com/snyk/agent-scan))
- **PR 3 (this) — LLM-as-judge review** ([`tesslio/skill-review`](https://github.com/tesslio/skill-review))

## How it runs

Triggered on PRs that touch `skills/**/SKILL.md`. The action shells out to `tessl skill review --json` per changed skill, then renders a single PR comment with a markdown table (updates in place on re-pushes — no duplicate comments). Tessl hosts the LLM judge, so **no `ANTHROPIC_API_KEY` is needed** — only the default `GITHUB_TOKEN` to post the comment.

`fail-threshold: 0` initially — report-only mode. We'll flip to a numeric gate (e.g. 70) once we have a baseline of real scores against this repo's skills. LLM judging is non-deterministic; setting a threshold before observing variance would flap.

## SHA pinning caveat

`tesslio/skill-review` has **zero tagged releases** as of 2026-06-04, so we pin to the current HEAD commit on `main`:

```
tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead  # main @ 2026-03-27
```

Per Grafana's GitHub Actions guidelines (commit-SHA pinning for zizmor compliance). The workflow file documents how to refresh the SHA.

**Contingency:** the action's internal dependency `tesslio/setup-tessl@v1` is being phased out for `@v2` (which needs `TESSL_TOKEN`). If the action breaks without warning, the fallback is to fork `tesslio/skill-review` into `grafana-actions/skill-review` and freeze the dependency.

## Test plan

- [ ] CI: workflow does NOT run on this PR (no SKILL.md changes) — that's expected behavior; it's gated on `paths: skills/**/SKILL.md`
- [ ] Follow-up: open a SKILL.md edit PR to confirm a single comment is posted and updates in place on re-push
- [ ] Observe scores across ~5–10 PRs before considering a non-zero `fail-threshold`

## Out of scope

- Batch-reviewing existing skills via this action — the action only reviews changed files in a PR. The local sweep script from the plan (`scripts/review-all-skills.sh`) is the path for backfill and will land in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)