### PR TITLE
ci: run scan + review checks on every PR (unblock non-skill PRs)

### DIFF
--- a/.github/workflows/agent-scan.yml
+++ b/.github/workflows/agent-scan.yml
@@ -5,8 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - 'skills/**/SKILL.md'
+    # Intentionally NO paths: filter — this workflow is a required status check
+    # in the main-branch ruleset. A paths-gated required check leaves non-skill
+    # PRs (e.g. Renovate digest bumps) in BLOCKED state forever because GitHub
+    # waits for a check that the trigger filter never fires. On PRs without a
+    # SKILL.md change the scan step's `if: steps.targets.outputs.dirs != ''`
+    # guard makes it a sub-second no-op pass.
 
 # Workflow defaults to no permissions; each job grants only what it needs.
 permissions: {}

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -3,8 +3,10 @@ name: Skill Review
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'skills/**/SKILL.md'
+    # Intentionally NO paths: filter — required-check + path-gated trigger
+    # would leave non-skill PRs BLOCKED forever (see agent-scan.yml for the
+    # full rationale). The tesslio/skill-review action auto-detects changed
+    # SKILL.md files internally and exits cleanly when none are present.
 
 # Workflow defaults to no permissions; each job grants only what it needs
 # (avoids zizmor/excessive-permissions on the workflow-wide block).


### PR DESCRIPTION
## Summary

Drops the `paths: ['skills/**/SKILL.md']` filter from both `agent-scan.yml` and `skill-review.yml`. Both are required status checks in the main-branch ruleset; combining "required" with "paths-gated" deadlocks any PR that doesn't touch a SKILL.md (e.g. Renovate's #35) because GitHub waits indefinitely for a check that the filter prevents from queuing.

## Behavior on non-skill PRs

| Workflow | What happens |
|---|---|
| `agent-scan` | "Identify scan targets" sees no changed SKILL.md → `targets.outputs.dirs` is empty → scan step's `if:` guard skips it → job passes in ~5 s |
| `skill-review` | Tessl action's internal `getChangedSkillFiles` returns `[]` → exits cleanly → job passes in ~10 s |

Verified during PR #34 testing — both workflows showed `pass` on the no-SKILL.md commit before the bonus `grafana-scenes` edit was added.

## Test plan

- [ ] CI on this PR (no SKILL.md changed) shows both new checks as `pass`
- [ ] After merge, re-run CI on Renovate's #35 — should clear `BLOCKED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)