### PR TITLE
fix(k6-docs): lift Tessl score 72 → 100 (clears 75 gate)

### DIFF
--- a/skills/grafana-k6/k6-docs/SKILL.md
+++ b/skills/grafana-k6/k6-docs/SKILL.md
@@ -34,14 +34,18 @@ Pick the workflow that matches the user's intent:
 
 ## Validating examples (always run before committing)
 
-Every code example in k6 docs must execute cleanly against `k6@master`. The minimum loop:
+Every code example in k6 documentation **and release notes** must execute cleanly against `k6@master`. The minimum loop:
 
 ```bash
-# 1. cd into the k6 repo (not k6-docs)
+# 1. cd into the k6 repo (not k6-docs or k6-DefinitelyTyped)
 cd ~/path/to/k6
 
-# 2. Run each example as a separate command (no &&)
+# 2. Make sure you're on master at the latest commit (the contract is k6@master)
+git checkout master
+git pull
+
+# 3. Run each example as a separate command (no &&)
 go run . run /path/to/script.js
 ```
 
-If the run fails: read the error, fix the example in the doc, re-run. Do not commit a doc edit whose example doesn't run clean. For the full multi-example workflow with parallel subagents, see [references/testing-workflow.md](references/testing-workflow.md).
+If the run fails: read the error, fix the example in the source (doc or release note), re-run. Do not commit a change whose example doesn't run clean against current `master`. For the full multi-example workflow with parallel subagents, see [references/testing-workflow.md](references/testing-workflow.md).

--- a/skills/grafana-k6/k6-docs/SKILL.md
+++ b/skills/grafana-k6/k6-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: k6-docs
 license: Apache-2.0
-description: Use when writing or reviewing k6 documentation across TypeScript types, user docs, and release notes.
+description: Write or review k6 documentation across the three k6 repositories - k6-DefinitelyTyped (TypeScript types), k6-docs (user documentation), and k6 (release notes / changelog). Applies k6 doc style conventions, generates TypeScript type definitions, drafts release notes, and validates examples by running them against k6@master. Use when working on k6 documentation, the k6 changelog, the k6 release notes, k6 API reference, k6 TypeScript types, load testing docs, or when the user asks to write, edit, or review anything in the k6, k6-docs, or k6-DefinitelyTyped repos - even if they don't explicitly say "documentation".
 ---
 
 # k6 Documentation
@@ -10,10 +10,10 @@ Document or review k6 features across three repositories: k6-DefinitelyTyped (Ty
 
 ## Workflow
 
-Based on user's action, follow the appropriate workflow:
+Pick the workflow that matches the user's intent:
 
-- **Write Documentation:** [Complete write workflow](references/workflows/write.md)
-- **Review Documentation:** [Complete review workflow](references/workflows/review.md)
+- **Write documentation:** follow [references/workflows/write.md](references/workflows/write.md)
+- **Review documentation:** follow [references/workflows/review.md](references/workflows/review.md)
 
 ## Quick References
 
@@ -25,9 +25,23 @@ Based on user's action, follow the appropriate workflow:
 
 ## Critical Rules
 
-- Never push automatically - always ask first
-- Never chain commands with `&&` or `;` - run each command separately (prevents failures)
-- Only document user-facing features - not internal implementation
-- Use `1.` for all numbered list items (not 1., 2., 3.)
-- Test with k6@master: first `cd /path/to/k6`, then `go run . run script.js` for each example
-- No "Co-Authored-By: Claude" or AI attribution
+- **Never push automatically** - always ask first
+- **Never chain commands with `&&` or `;`** - run each command separately (prevents failures)
+- **Only document user-facing features** - not internal implementation
+- **Use `1.` for every numbered list item** (not `1.`, `2.`, `3.`)
+- **Test every code example** against k6@master before committing
+- **No `Co-Authored-By: Claude` or AI attribution** in commits
+
+## Validating examples (always run before committing)
+
+Every code example in k6 docs must execute cleanly against `k6@master`. The minimum loop:
+
+```bash
+# 1. cd into the k6 repo (not k6-docs)
+cd ~/path/to/k6
+
+# 2. Run each example as a separate command (no &&)
+go run . run /path/to/script.js
+```
+
+If the run fails: read the error, fix the example in the doc, re-run. Do not commit a doc edit whose example doesn't run clean. For the full multi-example workflow with parallel subagents, see [references/testing-workflow.md](references/testing-workflow.md).


### PR DESCRIPTION
## Summary

`grafana-k6/k6-docs` scored **72** on Tessl's review rubric — below the 75 gate the `skill-review` workflow now enforces. Any PR touching this skill would be unmergeable until lifted. This PR hand-crafts the improvement to **100**.

## Approach: hand-craft, not `--optimize`

k6-docs is intentionally a routing document — 33 lines of overview pointing at `references/workflows/*.md` for procedural detail. This follows [Anthropic's progressive-disclosure pattern](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#progressive-disclosure-patterns). But Tessl's `contentJudge` only loads SKILL.md, so it scored the skill down for being "not independently actionable" — penalising correct architecture.

Running `tessl skill review --optimize` would have inlined content from references back into SKILL.md, undoing the deliberate disclosure design. Two surgical hand-edits get the same score lift without that regression.

## Changes

### 1. Description: 0.575/1.0 → 1.0/1.0 normalized

- Expanded "what" with concrete actions per Anthropic best-practices (style conventions, TypeScript type generation, release-note drafting, example validation)
- Added trigger variations (changelog, API reference, load testing docs, repo names)
- Added the "pushy" trigger per [skill-creator guidance](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md#write-the-skillmd) — fires even when the user doesn't explicitly say "documentation"

### 2. Body: actionability + workflow_clarity 2/3 → 3/3

- Added a "Validating examples" section with the minimum copy-paste-ready loop so SKILL.md is independently actionable without loading the bundle
- Added an explicit failure-recovery feedback loop (run → read error → fix → re-run → don't commit until clean)
- Preserved the routing layer + `references/` progressive disclosure (still scores 3/3 there)

## Score delta

| Dimension | Before | After |
|---|---:|---:|
| **reviewScore** | 72 | **100** |
| descriptionJudge.normalizedScore | 0.575 | 1.0 |
| contentJudge.conciseness | 3 | 3 |
| contentJudge.actionability | 2 | **3** |
| contentJudge.workflow_clarity | 2 | **3** |
| contentJudge.progressive_disclosure | 3 | 3 |

Verified via `tessl skill review --json skills/grafana-k6/k6-docs`.

## Test plan

- [x] Lint passes (`./scripts/lint-skills.sh skills/grafana-k6/k6-docs`)
- [x] Tessl reviewScore lifts above the 75 gate (72 → 100)
- [ ] CI: `skill-review` check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)