### PR TITLE
feat(skill-authoring): meta-skill distilling Anthropic guidance + Tessl rubric

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "grafana-core",
       "source": "./",
-      "description": "Skills for core Grafana concepts \u2014 dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
+      "description": "Skills for core Grafana concepts — dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -32,13 +32,14 @@
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
-        "./skills/grafana-core/alerting-irm"
+        "./skills/grafana-core/alerting-irm",
+        "./skills/grafana-core/skill-authoring"
       ]
     },
     {
       "name": "grafana-cloud",
       "source": "./",
-      "description": "Skills for Grafana Cloud \u2014 fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
+      "description": "Skills for Grafana Cloud — fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -77,7 +78,7 @@
     {
       "name": "grafana-lgtm",
       "source": "./",
-      "description": "Skills for the LGTM open-source stack \u2014 Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
+      "description": "Skills for the LGTM open-source stack — Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -102,7 +103,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins \u2014 bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -122,7 +123,7 @@
     {
       "name": "grafana-app-sdk",
       "source": "./",
-      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk \u2014 CUE schemas, reconcilers, and admission control",
+      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk — CUE schemas, reconcilers, and admission control",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -144,7 +145,7 @@
     {
       "name": "grafana-k6",
       "source": "./",
-      "description": "Skills for working with k6 \u2014 open-source load testing and performance testing",
+      "description": "Skills for working with k6 — open-source load testing and performance testing",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "grafana-core",
       "source": "./",
-      "description": "Skills for core Grafana concepts \u2014 dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
+      "description": "Skills for core Grafana concepts — dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -32,13 +32,14 @@
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
-        "./skills/grafana-core/alerting-irm"
+        "./skills/grafana-core/alerting-irm",
+        "./skills/grafana-core/skill-authoring"
       ]
     },
     {
       "name": "grafana-cloud",
       "source": "./",
-      "description": "Skills for Grafana Cloud \u2014 fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
+      "description": "Skills for Grafana Cloud — fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -77,7 +78,7 @@
     {
       "name": "grafana-lgtm",
       "source": "./",
-      "description": "Skills for the LGTM open-source stack \u2014 Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
+      "description": "Skills for the LGTM open-source stack — Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -102,7 +103,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins \u2014 bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -122,7 +123,7 @@
     {
       "name": "grafana-app-sdk",
       "source": "./",
-      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk \u2014 CUE schemas, reconcilers, and admission control",
+      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk — CUE schemas, reconcilers, and admission control",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -144,7 +145,7 @@
     {
       "name": "grafana-k6",
       "source": "./",
-      "description": "Skills for working with k6 \u2014 open-source load testing and performance testing",
+      "description": "Skills for working with k6 — open-source load testing and performance testing",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "grafana-core",
       "source": "./",
-      "description": "Skills for core Grafana concepts \u2014 dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
+      "description": "Skills for core Grafana concepts — dashboards, panels, PromQL, visualization, alerting, Alloy, Beyla, and OpenTelemetry",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -32,13 +32,14 @@
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
-        "./skills/grafana-core/alerting-irm"
+        "./skills/grafana-core/alerting-irm",
+        "./skills/grafana-core/skill-authoring"
       ]
     },
     {
       "name": "grafana-cloud",
       "source": "./",
-      "description": "Skills for Grafana Cloud \u2014 fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
+      "description": "Skills for Grafana Cloud — fleet management, cloud integrations, adaptive metrics, AI/ML, infrastructure monitoring, database observability, private connectivity, cost management, and account administration",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -77,7 +78,7 @@
     {
       "name": "grafana-lgtm",
       "source": "./",
-      "description": "Skills for the LGTM open-source stack \u2014 Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
+      "description": "Skills for the LGTM open-source stack — Loki (logs), Grafana Tempo (traces), Grafana Mimir/Prometheus (metrics), and Grafana Pyroscope (profiles)",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -102,7 +103,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins \u2014 bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -122,7 +123,7 @@
     {
       "name": "grafana-app-sdk",
       "source": "./",
-      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk \u2014 CUE schemas, reconcilers, and admission control",
+      "description": "Skills for building apps on the Grafana App Platform using grafana-app-sdk — CUE schemas, reconcilers, and admission control",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -144,7 +145,7 @@
     {
       "name": "grafana-k6",
       "source": "./",
-      "description": "Skills for working with k6 \u2014 open-source load testing and performance testing",
+      "description": "Skills for working with k6 — open-source load testing and performance testing",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/skills/grafana-core/skill-authoring/SKILL.md
+++ b/skills/grafana-core/skill-authoring/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: skill-authoring
+license: Apache-2.0
+description: Author, audit, and improve Grafana SKILL.md files against Anthropic's published Agent Skills guidance and the four-dimension rubric the grafana/skills CI gate uses (conciseness, actionability, workflow clarity, progressive disclosure). Applies the canonical SKILL.md structure (YAML frontmatter + body + references/ + scripts/ + assets/), the "pushy description" trigger pattern, the three-level progressive-disclosure model, and the validate-fix-rerun feedback loop. Use when creating a new skill in this repo, when reviewing a skill PR, when a skill's Tessl review score is below 75 (the merge gate), when a skill's description isn't getting picked up by agents, when restructuring a long SKILL.md into a bundle, or when the user asks how to write, improve, optimize, audit, or fix a skill - even if they don't say "skill" explicitly (e.g. "this isn't triggering", "Tessl scored this 72", "split this doc").
+---
+
+# Authoring & Improving Grafana Skills
+
+How to write, review, and improve SKILL.md files so they pass the repo's CI gate and score well against the Anthropic-aligned rubric Tessl uses.
+
+## When to use this skill
+
+- Creating a new skill (use the [decision tree](#decision-tree-for-a-new-skill) below)
+- A PR fails the `skill-review` workflow with a score below 75
+- An existing skill is technically passing but you want it ≥85 (the recommended baseline)
+- The description "isn't triggering" — agents skip past it when they should pick it up
+- SKILL.md is over 500 lines and starting to feel monolithic
+- Reviewing a teammate's skill PR
+
+## Critical rules (always)
+
+1. **Description is the primary trigger** — third-person, ≤1024 chars, must include explicit "Use when..." phrasing AND list concrete trigger terms users naturally say. See [references/descriptions.md](references/descriptions.md) for the pushy-description pattern that combats undertriggering.
+2. **Body under 500 lines** — split into `references/*.md` if approaching the limit. SKILL.md is the routing layer, not the entire knowledge base.
+3. **One level of nesting for references** — link from SKILL.md directly, never `SKILL.md → a.md → b.md`. Claude may use `head -100` previews on nested chains and miss content.
+4. **Imperative voice** — "Run X" not "You should run X" not "It is important to run X". Explain *why* over heavy-handed `MUST` markers.
+5. **Concrete examples beat prose** — copy-paste-ready commands, real config snippets. Tessl's `actionability` dimension scores this directly.
+6. **No reserved words in `name`** — `anthropic` and `claude` are forbidden in skill names.
+7. **No time-sensitive language in the body** — "after August 2025…" rots. Use an `<details>` "Old patterns" section for legacy info instead.
+8. **Validate before committing** — `./scripts/lint-skills.sh skills/<plugin>/<your-skill>` clean + Tessl score ≥75 (run `tessl skill review --json <dir>`).
+
+## The rubric this repo is graded against
+
+The `skill-review` CI workflow fails any PR where a touched SKILL.md scores below **75**. Four dimensions, each 0-3:
+
+| Dimension | What it measures | Where to look in this skill |
+|---|---|---|
+| **Conciseness** | No content Claude already knows | [references/rubric.md § Conciseness](references/rubric.md#conciseness) |
+| **Actionability** | Concrete examples, imperative commands, copy-paste-ready | [references/rubric.md § Actionability](references/rubric.md#actionability) |
+| **Workflow clarity** | Numbered steps, validation checkpoints, feedback loops | [references/rubric.md § Workflow clarity](references/rubric.md#workflow-clarity) |
+| **Progressive disclosure** | Three-level loading (metadata / SKILL.md / bundle) | [references/rubric.md § Progressive disclosure](references/rubric.md#progressive-disclosure) |
+
+For full per-dimension scoring and Anthropic-doc mapping, see [references/rubric.md](references/rubric.md).
+
+## Decision tree for a new skill
+
+1. **What product / domain does this skill belong to?**
+   Pick the right plugin folder: `grafana-core/`, `grafana-cloud/`, `grafana-lgtm/`, `grafana-app-sdk/`, `grafana-k6/`, `grafana-plugins/`. If none fits cleanly, ask the user before creating a new plugin group (a new group requires updating three `marketplace.json` files).
+
+2. **Estimate body length.**
+   - <200 lines of substance → single `SKILL.md`, no bundle
+   - 200-500 lines → `SKILL.md` + `references/<topic>.md` for the long-form material
+   - >500 lines → mandatory bundle split; see [references/anatomy.md § Splitting strategies](references/anatomy.md#splitting-strategies)
+
+3. **Write a "pushy" description first.**
+   The description is the only thing always loaded into context. If agents don't trigger the skill, nothing else matters. See [references/descriptions.md](references/descriptions.md) for the pattern.
+
+4. **Draft body with the four-dimension rubric in mind.**
+   - Cut every sentence Claude already knows (Conciseness)
+   - Replace prose explanations with code blocks (Actionability)
+   - Number every multi-step procedure + add a validation step at the end (Workflow clarity)
+   - If you reach for `<details>`, consider whether that content belongs in `references/` instead (Progressive disclosure)
+
+5. **Register in marketplace manifests.**
+   Add the skill path to the `skills` array in all three:
+   - `.claude-plugin/marketplace.json`
+   - `.cursor-plugin/marketplace.json`
+   - `.agents-plugin/marketplace.json`
+
+6. **Validate locally.**
+   ```bash
+   # 1. Lint clean (0 errors)
+   ./scripts/lint-skills.sh skills/<plugin>/<your-skill>
+
+   # 2. Tessl reviewScore ≥75 (the CI gate)
+   tessl skill review --json skills/<plugin>/<your-skill> | jq '.review.reviewScore'
+
+   # 3. If below 75 or you want ≥85: run --optimize (requires auth)
+   tessl skill review --optimize --yes --max-iterations 3 skills/<plugin>/<your-skill>
+   ```
+
+   If the run fails: read the lint error / Tessl suggestion, fix, re-run. Don't open the PR until both checks pass cleanly. The feedback-loop pattern beats one-shot writing.
+
+## Fixing a low-scoring existing skill
+
+1. Get the per-dimension scores + suggestions:
+   ```bash
+   tessl skill review --json skills/<plugin>/<name> \
+     | jq '{score: .review.reviewScore, scores: .contentJudge.evaluation.scores, suggestions: .contentJudge.evaluation.suggestions}'
+   ```
+
+2. Pick the lowest-scoring dimension and apply the fix pattern from [references/rubric.md](references/rubric.md):
+   - **Conciseness 1-2** → cut intros, definitions, "what X is" paragraphs
+   - **Actionability 1-2** → replace prose with code blocks and CLI commands
+   - **Workflow clarity 1-2** → add numbered steps + validation checkpoints
+   - **Progressive disclosure 1-2** → split into `references/*.md`
+
+3. If the skill is **intentionally a routing document** (like `grafana-k6/k6-docs`), don't let `--optimize` inline the bundle back into SKILL.md. Hand-craft: add a minimal copy-paste-ready "validation loop" inline so SKILL.md is independently actionable, but keep the references for the full procedural detail.
+
+4. Re-score and iterate. The `--max-iterations 3` flag on `--optimize` is the default budget; raise to 5-10 for stubborn cases.
+
+## Anti-patterns to avoid
+
+- **Vague descriptions** ("Helps with metrics", "Does stuff with files") — agents won't trigger.
+- **First-person voice** ("I can help you process Excel") — Anthropic explicitly calls this out; use third-person.
+- **`MUST` / `ALWAYS` / `NEVER` everywhere** — reserve for genuine hard constraints. Otherwise explain *why*.
+- **Time-sensitive phrasing** in the body — "Before August 2025…" rots.
+- **Windows-style paths** (`scripts\helper.py`) — always use forward slashes.
+- **Dangling references** — `[see references/x.md](references/x.md)` where the file doesn't exist. The linter doesn't catch this; reviewers should.
+- **Inlining content during `--optimize`** when the skill was deliberately a routing layer (see [references/anatomy.md § When NOT to inline](references/anatomy.md#when-not-to-inline)).
+- **Skipping the marketplace registration** — the skill exists on disk but isn't installable via any plugin marketplace.
+
+For a longer list with examples, see [references/anti-patterns.md](references/anti-patterns.md).
+
+## References
+
+- [`references/descriptions.md`](references/descriptions.md) — the pushy-description pattern + trigger-term checklist
+- [`references/rubric.md`](references/rubric.md) — per-dimension scoring with Anthropic-doc citations and concrete fix patterns
+- [`references/anatomy.md`](references/anatomy.md) — three-level progressive disclosure, bundle layout, splitting strategies
+- [`references/anti-patterns.md`](references/anti-patterns.md) — what NOT to do, with examples
+- [Anthropic — Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)
+- [anthropics/skills — skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)
+- [The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)

--- a/skills/grafana-core/skill-authoring/references/anatomy.md
+++ b/skills/grafana-core/skill-authoring/references/anatomy.md
@@ -1,0 +1,139 @@
+# Anatomy of a skill bundle
+
+## The canonical layout
+
+```
+skills/<plugin>/<skill-name>/
+├── SKILL.md              (required: YAML frontmatter + body)
+├── references/           (markdown loaded only when needed)
+│   ├── topic-a.md
+│   └── topic-b.md
+├── scripts/              (executable code; not loaded into context)
+│   └── helper.py
+└── assets/               (templates, fonts, images used as output)
+    └── template.json
+```
+
+Source: [anthropics/skills — skill-creator SKILL.md § Anatomy of a Skill](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md).
+
+## The three-level loading model
+
+| Level | What's loaded | When | Token cost |
+|---|---|---|---|
+| 1. Metadata | `name` + `description` | Always (at agent startup) | ~50-200 tokens per skill |
+| 2. SKILL.md body | Full markdown body | When the agent decides the skill triggers | ~500-3000 tokens once loaded |
+| 3. Bundle | `references/*.md`, `assets/*`, `scripts/*` (via bash, not context) | On demand, only the specific file the body links to | Zero until accessed |
+
+Implication: **the cheapest way to lift Conciseness is to move heavy content from level 2 to level 3.**
+
+## SKILL.md size guidance
+
+- **Aim:** ≤200 lines for the body
+- **Hard guideline:** ≤500 lines (Anthropic's documented limit)
+- **Soft threshold:** If you're past 250 lines, ask whether some sections should be `references/*.md`
+
+## Splitting strategies
+
+### By domain (when a skill spans multiple platforms/frameworks)
+
+```
+cloud-integrations/
+├── SKILL.md           (overview + selection logic: "if AWS, see references/aws.md…")
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    ├── azure.md
+    └── confluent.md
+```
+
+Claude reads SKILL.md, sees the user mentioned AWS, reads only `references/aws.md`. The other three never load → zero token cost.
+
+### By depth (when overview vs. detail is clear)
+
+```
+react-19-plugin-migration/
+├── SKILL.md           (decision tree + critical rules + happy path)
+└── references/
+    ├── eslint-9-migration.md  (deep dive for the ESLint sub-step)
+    └── troubleshooting.md     (failure modes + fixes)
+```
+
+### By format (when reference material doesn't fit the prose flow)
+
+```
+admin/
+├── SKILL.md
+└── references/
+    ├── sso.md           (full OAuth/SAML/GitHub OAuth configs)
+    ├── terraform.md     (Terraform provider examples)
+    └── api-reference.md (Cloud API + Admin endpoints + audit logs)
+```
+
+## Reference-file conventions
+
+- **Filename**: short, descriptive, lowercase-with-hyphens (`troubleshooting.md`, not `Troubleshooting.md` or `Docs.md`)
+- **Top of file**: if >100 lines, include a `## Contents` table of contents so Claude can navigate during a partial read
+- **Linked one level deep from SKILL.md** — never a chain (`SKILL.md → a.md → b.md`)
+- **Inline relative links** — `[full setup guide](references/sso.md)` from SKILL.md, not absolute URLs
+
+## When NOT to inline
+
+Tessl's rubric penalizes routing documents (a thin SKILL.md that defers to references/) by scoring them down for "not independently actionable". The naive response is to inline content from references back into SKILL.md, which undoes the deliberate progressive disclosure.
+
+**Better fix for routing skills:** add a minimal copy-paste-ready "happy path" loop inline so SKILL.md is independently actionable for the most common task, while preserving the bundle for everything else.
+
+Concrete example — `grafana-k6/k6-docs` (33 lines in its SKILL.md):
+
+```markdown
+## Workflow
+
+Pick the workflow that matches the user's intent:
+
+- **Write documentation:** follow [references/workflows/write.md](references/workflows/write.md)
+- **Review documentation:** follow [references/workflows/review.md](references/workflows/review.md)
+
+## Validating examples (always run before committing)
+
+Every code example in k6 documentation and release notes must execute cleanly against `k6@master`:
+
+​```bash
+cd ~/path/to/k6
+git checkout master
+git pull
+go run . run /path/to/script.js
+​```
+
+If the run fails: read the error, fix the source, re-run. Don't commit a doc edit whose
+example doesn't run clean. For the full multi-example workflow with parallel subagents,
+see [references/testing-workflow.md](references/testing-workflow.md).
+```
+
+This pattern (the file lifted its score from 72 → 100):
+1. Keeps the routing layer + bundle architecture
+2. Adds enough inline content that Claude can do the common task without loading any bundle file
+3. Still defers full procedural detail to the references/
+
+## scripts/ directory
+
+Use when the skill includes deterministic operations Claude shouldn't reinvent:
+- File transformations (PDF extraction, image resizing)
+- Validation harnesses
+- Output formatters
+
+Scripts are executed via bash; **their contents do not consume context tokens**, only their output does. Big performance win for skills that run the same code repeatedly.
+
+Make scripts executable (`chmod +x`) — the linter warns otherwise.
+
+## assets/ directory
+
+Use for template files, fonts, images, or other static resources the skill produces as output. Like scripts, assets don't consume tokens until referenced.
+
+## Marketplace registration
+
+After creating the skill directory, add it to the `skills` array in all three marketplace files:
+
+- `.claude-plugin/marketplace.json`
+- `.cursor-plugin/marketplace.json`
+- `.agents-plugin/marketplace.json`
+
+The three must stay in sync. CI's `validate` job will fail any PR where they diverge.

--- a/skills/grafana-core/skill-authoring/references/anatomy.md
+++ b/skills/grafana-core/skill-authoring/references/anatomy.md
@@ -84,7 +84,7 @@ Tessl's rubric penalizes routing documents (a thin SKILL.md that defers to refer
 
 Concrete example — `grafana-k6/k6-docs` (33 lines in its SKILL.md):
 
-```markdown
+````markdown
 ## Workflow
 
 Pick the workflow that matches the user's intent:
@@ -96,17 +96,17 @@ Pick the workflow that matches the user's intent:
 
 Every code example in k6 documentation and release notes must execute cleanly against `k6@master`:
 
-​```bash
+```bash
 cd ~/path/to/k6
 git checkout master
 git pull
 go run . run /path/to/script.js
-​```
+```
 
 If the run fails: read the error, fix the source, re-run. Don't commit a doc edit whose
 example doesn't run clean. For the full multi-example workflow with parallel subagents,
 see [references/testing-workflow.md](references/testing-workflow.md).
-```
+````
 
 This pattern (the file lifted its score from 72 → 100):
 1. Keeps the routing layer + bundle architecture

--- a/skills/grafana-core/skill-authoring/references/anti-patterns.md
+++ b/skills/grafana-core/skill-authoring/references/anti-patterns.md
@@ -1,0 +1,243 @@
+# Anti-patterns: what NOT to do in a skill
+
+Distilled from [Anthropic's Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices), [skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md), and the Tessl rubric this repo's CI gate uses.
+
+## Description anti-patterns
+
+### First-person / second-person voice
+
+```yaml
+# Wrong
+description: I can help you process Excel files and generate reports.
+description: You can use this to process Excel files.
+
+# Right (third-person)
+description: Processes Excel files and generates reports. Use when analyzing spreadsheets, building pivot tables, or generating charts from .xlsx data.
+```
+
+### Vague "what"
+
+```yaml
+# Wrong
+description: Helps with metrics queries.
+
+# Right (specific actions + concrete outputs)
+description: Write PromQL queries for Prometheus and Grafana Mimir. Calculates rates, builds histogram quantiles, debugs cardinality, and optimizes slow queries. Use when writing metric queries, building Grafana panels, working with recording rules, or troubleshooting Prometheus performance.
+```
+
+### Missing "Use when" trigger
+
+```yaml
+# Wrong (no triggers — agent can't tell when to load it)
+description: PromQL query writing for Prometheus.
+
+# Right (explicit triggers)
+description: PromQL query writing for Prometheus and Grafana Mimir. Use when writing metric queries, building Grafana panels, calculating rates, working with histograms, or optimizing slow queries.
+```
+
+### No trigger variations / no pushy clause
+
+```yaml
+# Wrong (only the canonical term — agent skips this when user says synonyms)
+description: Use when writing k6 documentation.
+
+# Right (variations + pushy clause)
+description: ... Use when working on k6 documentation, the k6 changelog, the k6 release notes, k6 API reference, k6 TypeScript types, load testing docs - even if the user doesn't explicitly say "documentation".
+```
+
+### Reserved words in `name`
+
+```yaml
+# Wrong
+name: anthropic-helper
+name: claude-tools
+
+# Right
+name: skill-authoring
+name: prompt-helper
+```
+
+## Body anti-patterns
+
+### Time-sensitive language
+
+```markdown
+# Wrong (rots — "after August 2025" is meaningless in 2027)
+If you're doing this before August 2025, use the old API.
+After August 2025, use the new API.
+
+# Right (`<details>` for legacy info, current path inline)
+## Current method
+Use the v2 API endpoint: `api.example.com/v2/messages`
+
+<details>
+<summary>Legacy v1 API (deprecated 2025-08)</summary>
+
+The v1 API used: `api.example.com/v1/messages`. No longer supported.
+</details>
+```
+
+### Windows-style paths
+
+```markdown
+# Wrong (breaks on Unix)
+Run `scripts\helper.py` to process the input.
+
+# Right (forward slashes everywhere)
+Run `scripts/helper.py` to process the input.
+```
+
+### Inconsistent terminology
+
+Pick one term per concept and stick with it. Mixing breaks Claude's pattern-matching:
+
+```markdown
+# Wrong (same concept, three names)
+The API endpoint is /messages. Send a POST to the URL. The API route accepts JSON.
+
+# Right (one term)
+The API endpoint is /messages. Send a POST to the endpoint. The endpoint accepts JSON.
+```
+
+### Heavy-handed `MUST` markers without justification
+
+```markdown
+# Wrong (no explanation, feels like noise)
+You MUST validate the input. You MUST handle errors. You MUST log the result.
+
+# Right (explain why, reserve MUST for genuine hard constraints)
+Validate the input before submitting — the API returns a 422 for malformed payloads
+without telling you which field failed, which is hard to debug after the fact.
+
+Always handle the 429 response with exponential backoff; the rate limiter resets
+on a sliding window, not a fixed window.
+```
+
+### "There are many ways to do this" hedging
+
+```markdown
+# Wrong (forces Claude to pick — wastes time on irrelevant alternatives)
+You can use pypdf, or pdfplumber, or PyMuPDF, or pdf2image. Each has trade-offs...
+
+# Right (pick a default, mention the escape hatch)
+Use pdfplumber for text extraction. For scanned PDFs requiring OCR, use pdf2image
+with pytesseract instead.
+```
+
+### Dangling references
+
+```markdown
+# Wrong (file doesn't exist)
+For full setup, see [references/setup-guide.md](references/setup-guide.md)
+```
+
+The linter doesn't catch this. Reviewers should. Either create the file or remove the link.
+
+### Too-deep reference chains
+
+```markdown
+# Wrong: SKILL.md → advanced.md → details.md
+# (Claude may preview with `head -100` and miss content past level 2)
+
+# Right: keep all references one level deep from SKILL.md
+SKILL.md
+├── references/advanced.md
+└── references/details.md
+```
+
+## Workflow anti-patterns
+
+### Implicit ordering
+
+```markdown
+# Wrong (ordering is in the prose; easy to miss)
+Configure X. Make sure to do Y before X actually. Don't forget Z either.
+
+# Right (explicit numbered steps)
+1. Do Y first
+2. Then configure X
+3. Then run Z to verify
+```
+
+### No validation checkpoints
+
+```markdown
+# Wrong (no way to know if step 1 worked before doing step 2)
+1. Create the contact point
+2. Add the notification policy
+3. Write the alert rule
+
+# Right (validate after each step)
+1. Create the contact point
+   - **Verify**: `curl .../api/v1/provisioning/contact-points` returns it
+2. Add the notification policy
+   - **Verify**: send a test alert; output should show the contact point name
+3. Write the alert rule
+   - **Verify**: alert fires correctly under simulated conditions
+```
+
+### "Punting to Claude" in scripts
+
+```python
+# Wrong (script lets Claude figure out failure)
+def process_file(path):
+    return open(path).read()   # fails on FileNotFoundError, no fallback
+
+# Right (handle the error explicitly)
+def process_file(path):
+    try:
+        with open(path) as f:
+            return f.read()
+    except FileNotFoundError:
+        print(f"File {path} not found, creating default")
+        with open(path, "w") as f:
+            f.write("")
+        return ""
+```
+
+### Voodoo constants
+
+```python
+# Wrong (no justification for the values)
+TIMEOUT = 47
+RETRIES = 5
+
+# Right (self-documenting)
+# HTTP requests typically complete within 30 seconds; longer timeout for slow networks
+REQUEST_TIMEOUT = 30
+# Three retries balances reliability vs speed; most flakes resolve by the second retry
+MAX_RETRIES = 3
+```
+
+## Structural anti-patterns
+
+### Skill body acts as a reference dump
+
+If the skill has no workflow guidance and is just a list of API endpoints / config snippets / capabilities, the user has to do all the orchestration themselves. Tessl scores this 1-2/3 on workflow_clarity.
+
+Fix: pick the 2-3 most common user tasks, write numbered workflows for them at the top, and move the reference-dump material to `references/<topic>.md`.
+
+### One mega-SKILL.md when domains are clearly separable
+
+If the skill covers AWS + GCP + Azure in one file, Claude loads all three even when the user only needs one. Split per domain:
+
+```
+cloud-deploy/
+├── SKILL.md (overview + selection)
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+### Skipping marketplace registration
+
+The skill is functionally created on disk but not installable from any marketplace. CI's `validate` job catches inter-manifest divergence but doesn't flag a skill that's missing from all three.
+
+After creating the skill directory:
+
+1. Add the path to `.claude-plugin/marketplace.json` → relevant plugin's `skills` array
+2. Same for `.cursor-plugin/marketplace.json`
+3. Same for `.agents-plugin/marketplace.json`
+
+All three must list the same skill path. Keep them in sync.

--- a/skills/grafana-core/skill-authoring/references/descriptions.md
+++ b/skills/grafana-core/skill-authoring/references/descriptions.md
@@ -1,0 +1,86 @@
+# Writing skill descriptions that actually trigger
+
+The `description` field is the only part of a skill always loaded into the agent's context. Everything else — the SKILL.md body, the bundle files — is only read after the agent decides this skill applies. **If the description is weak, none of the rest of your work matters.**
+
+## The four scoring dimensions (Tessl `descriptionJudge`)
+
+Each rated 0-3, normalized to a 0-1 final score:
+
+| Dimension | What it checks |
+|---|---|
+| **Specificity** | Lists concrete actions the skill performs (not just "helps with X") |
+| **Trigger term quality** | Includes natural terms users actually say (variations, synonyms) |
+| **Completeness** | Has both *what it does* AND *when to use* — usually via "Use when..." |
+| **Distinctiveness / conflict risk** | Clearly scoped; won't fight other skills for activation |
+
+## The pushy pattern (Anthropic-recommended)
+
+From [Anthropic's skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md):
+
+> Claude has a tendency to "undertrigger" skills — to not use them when they'd be useful. To combat this, please make the skill descriptions a little bit "pushy". So for instance, instead of "How to build a simple fast dashboard to display internal Anthropic data.", you might write "How to build a simple fast dashboard to display internal Anthropic data. **Make sure to use this skill whenever the user mentions dashboards, data visualization, internal metrics, or wants to display any kind of company data, even if they don't explicitly ask for a 'dashboard.'**"
+
+The pushy clause forces the agent to consider the skill across phrasings users actually say.
+
+## Anatomy of a strong description
+
+```yaml
+description: <concrete-actions-the-skill-performs>. Applies <specific-conventions/methodologies>, generates <specific-outputs>, and validates <specific-checks>. Use when <task-A>, <task-B>, <task-C>, or when the user asks to <verb-1>, <verb-2>, <verb-3> - even if they don't explicitly say "<the-narrow-canonical-term>".
+```
+
+Three parts:
+
+1. **What** — concrete actions, not vague "helps with". List specific outputs the skill produces.
+2. **Use when** — explicit triggers. Multiple scenarios, ideally including domain-specific terms (repo names, CLI names, product names).
+3. **Pushy clause** — the "even if they don't explicitly say…" part. This catches the user phrasings that miss the canonical term.
+
+## Strong vs weak examples
+
+### Weak
+
+```yaml
+# Vague "what", no "when", no trigger variations
+description: Helps with k6 documentation.
+
+# First-person, no "when"
+description: I help you write k6 docs and TypeScript types.
+
+# "When" is too narrow; missing trigger variations and pushy clause
+description: Use when writing or reviewing k6 documentation across TypeScript types, user docs, and release notes.
+```
+
+### Strong (k6-docs from this repo, score 1.0/1.0 after rewrite)
+
+```yaml
+description: >
+  Write or review k6 documentation across the three k6 repositories - k6-DefinitelyTyped (TypeScript types),
+  k6-docs (user documentation), and k6 (release notes / changelog). Applies k6 doc style conventions,
+  generates TypeScript type definitions, drafts release notes, and validates examples by running them
+  against k6@master. Use when working on k6 documentation, the k6 changelog, the k6 release notes,
+  k6 API reference, k6 TypeScript types, load testing docs, or when the user asks to write, edit, or
+  review anything in the k6, k6-docs, or k6-DefinitelyTyped repos - even if they don't explicitly
+  say "documentation".
+```
+
+Why it works:
+- Specific outputs: TypeScript type definitions, release notes, example validation
+- Trigger variations: changelog, release notes, API reference, repo names, "load testing docs"
+- Pushy clause: catches users editing the underlying repos without saying "documentation"
+
+## Hard limits
+
+| Limit | Value | Source |
+|---|---|---|
+| Max length | 1024 chars | Agent Skills spec |
+| Voice | Third-person | Anthropic best-practices doc |
+| XML tags | Not allowed | Agent Skills spec |
+| Reserved words in `name` (NOT description) | `anthropic`, `claude` | Anthropic best-practices doc |
+
+## Checklist before opening a PR
+
+- [ ] Third-person ("Processes X" not "I process X" or "You can process X")
+- [ ] Explicit "Use when..." clause
+- [ ] Pushy clause at the end ("even if they don't say…")
+- [ ] At least 4-5 trigger-term variations users naturally say
+- [ ] ≤1024 chars
+- [ ] No reserved words in `name`
+- [ ] Concrete actions, not "helps with"

--- a/skills/grafana-core/skill-authoring/references/rubric.md
+++ b/skills/grafana-core/skill-authoring/references/rubric.md
@@ -1,0 +1,209 @@
+# The four-dimension rubric: per-dimension scoring + fix patterns
+
+Tessl's `contentJudge` (the body-scoring half of the review) uses these four dimensions, each 0-3, weighted into the overall `reviewScore` shown in CI. The rubric is aligned with Anthropic's published best-practices doc.
+
+## Contents
+
+- [Conciseness](#conciseness)
+- [Actionability](#actionability)
+- [Workflow clarity](#workflow-clarity)
+- [Progressive disclosure](#progressive-disclosure)
+- [Combined heuristic: how to read a low score](#combined-heuristic)
+
+## Conciseness
+
+**What it scores:** Does every sentence justify its token cost? Or does the skill spend tokens explaining things Claude already knows?
+
+**Anthropic's principle** ([best-practices doc § *Concise is key*](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices)):
+
+> Default assumption: Claude is already very smart. Only add context Claude doesn't already have. Challenge each piece of information: "Does Claude really need this explanation?" "Can I assume Claude knows this?" "Does this paragraph justify its token cost?"
+
+**Common 2/3 patterns to cut:**
+
+- Intro paragraphs explaining what the technology is ("PromQL is a functional query language…", "Loki is a log aggregation system…") — Claude knows
+- "First, install X, then run Y, then verify Z works" prose where each step could be a one-line code block
+- Repeated cautions ("never drop a distinguishing label" said three times)
+- "Why this matters" paragraphs longer than the actual rule
+- Verbose `<details><summary>What is X?</summary>` blocks
+
+**Fix pattern:**
+
+```diff
+- ## Querying metrics
+-
+- PromQL is a functional query language that lets you query time-series data. Each query
+- consists of selectors (which series), operators (what to compute), and functions (how to
+- aggregate). For example, to get the request rate for an API endpoint, you'd write:
+-
+- ```promql
+- rate(http_requests_total{job="api"}[5m])
+- ```
+
++ ## Querying metrics
++
++ ```promql
++ rate(http_requests_total{job="api"}[5m])
++ ```
++ Standard PromQL — selector, function, range vector.
+```
+
+The code is the explanation. The prose around it was tax.
+
+## Actionability
+
+**What it scores:** Could Claude, reading this once, do the task copy-paste? Or does Claude have to fill gaps from its own knowledge?
+
+**Strong patterns:**
+
+- Copy-paste-ready CLI commands with concrete arguments (not placeholders like `<your-token>` everywhere)
+- Complete config snippets, not "configure X like Y"
+- Templates with explicit `[Title]` / `[Section]` placeholders the user can fill
+- Explicit `Input:` / `Output:` pairs for output-shape teaching
+
+**Weak patterns (the 2/3 trap):**
+
+- "Use the appropriate library to do X" without naming the library
+- Placeholders that hide ambiguity: "Set the value to <appropriate>"
+- "There are many ways to do this, here are some…" — pick one, ship it
+- Discussing trade-offs before showing the solution
+
+**Fix pattern:**
+
+```diff
+- ### Setup
+-
+- You'll need to configure Alloy with the appropriate scrape targets. Most users will want
+- to start with a basic configuration and extend it.
+
++ ### Setup
++
++ ```alloy
++ prometheus.scrape "node_exporter" {
++   targets    = [{"__address__" = "localhost:9100"}]
++   forward_to = [prometheus.remote_write.default.receiver]
++ }
++
++ prometheus.remote_write "default" {
++   endpoint {
++     url = sys.env("PROMETHEUS_REMOTE_WRITE_URL")
++   }
++ }
++ ```
+```
+
+## Workflow clarity
+
+**What it scores:** Multi-step procedures with explicit ordering, decision points, and validation checkpoints.
+
+**Strong patterns:**
+
+- Numbered steps where order matters
+- Explicit `if validation fails, do X; else continue` branches
+- A copy-able checklist Claude can paste into its response
+- Validate → fix → re-run feedback loops written out
+
+**Weak patterns:**
+
+- Bullet list of capabilities with no ordering
+- "Configure X, then Y, then Z" without per-step validation
+- No "what to do if it fails" guidance
+- Implicit ordering ("Make sure to do A. By the way, you also need B before A")
+
+**Fix pattern:**
+
+```diff
+- ## Setting up alerts
+-
+- Create contact points, add notification policies, write the alert rules. Make sure to
+- test routing before going live.
+
++ ## Setting up alerts
++
++ 1. **Create contact points** (where notifications go):
++    ```bash
++    curl -X POST .../api/v1/provisioning/contact-points -d @contact-points.json
++    # Verify:
++    curl .../api/v1/provisioning/contact-points | jq '.[].name'
++    ```
++
++ 2. **Add notification policies** (which alerts go where):
++    ```bash
++    curl -X POST .../api/v1/provisioning/policies -d @policies.json
++    ```
++
++ 3. **Write alert rules**:
++    ```bash
++    curl -X POST .../api/v1/provisioning/alert-rules -d @rules.json
++    ```
++
++ 4. **Verify routing** before going live:
++    ```bash
++    curl -X POST .../api/v1/provisioning/policies/test -d @test-alert.json
++    # If output doesn't show the expected contact point, re-check matchers in step 2.
++    ```
+```
+
+The "verify" + "what to do if it fails" steps are what lift a workflow_clarity score from 2 to 3.
+
+## Progressive disclosure
+
+**What it scores:** Are you using the three-level loading model correctly? Or is everything dumped into one 600-line SKILL.md?
+
+**The three levels** ([skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md)):
+
+1. **Metadata** (name + description) — always loaded, ~100 words
+2. **SKILL.md body** — loaded when the skill triggers, <500 lines
+3. **Bundled resources** (scripts/, references/, assets/) — loaded only when needed
+
+**Strong patterns:**
+
+- SKILL.md under 200 lines for the routing layer
+- `references/*.md` for detailed material, linked one level deep
+- Domain-organized refs: `references/aws.md`, `references/gcp.md`, `references/azure.md` (Claude reads only the relevant one)
+- Reference files >100 lines have a table of contents at the top
+
+**Weak patterns:**
+
+- One 800-line SKILL.md with sections that should be separate files
+- Nested references: `SKILL.md → a.md → b.md` (Claude may truncate at level 2)
+- Dangling references — `[see X](references/x.md)` where the file doesn't exist
+- All content inline even when there are clear domain boundaries
+
+**Fix pattern (split):**
+
+Before:
+```
+skills/grafana-cloud/admin/
+└── SKILL.md  (244 lines, includes SSO config, Terraform examples, full API endpoint reference)
+```
+
+After:
+```
+skills/grafana-cloud/admin/
+├── SKILL.md            (under 100 lines: overview, workflows, RBAC, service accounts)
+└── references/
+    ├── sso.md          (OAuth + SAML + GitHub OAuth configs)
+    ├── terraform.md    (Terraform examples)
+    └── api-reference.md (Cloud API + Admin endpoints + audit logs)
+```
+
+Then SKILL.md links to each `references/*.md` one level deep.
+
+### When NOT to split
+
+Some skills are intentionally short routing documents (e.g. `grafana-k6/k6-docs` — 33 lines of overview pointing at a deep `references/workflows/*.md` bundle). The four-dimension rubric penalizes these for "not independently actionable", BUT the architecture is correct.
+
+For routing documents: add a minimal copy-paste-ready "validation loop" inline so SKILL.md is independently actionable for the most common task, while preserving the bundle for everything else. See `skills/grafana-k6/k6-docs/SKILL.md` for the pattern that lifted its score from 72 → 100 without losing the bundle.
+
+## Combined heuristic
+
+If you see a 2/3 across all four dimensions, the skill is doing too much narrative and not enough structure. If just one dimension is low:
+
+| Low dimension | First fix to try |
+|---|---|
+| Conciseness | Cut the introduction. Cut explanations of what known technologies are. |
+| Actionability | Replace one prose paragraph per section with a code block. |
+| Workflow clarity | Add numbered steps + one validation step per workflow. |
+| Progressive disclosure | Split sections >50 lines into `references/*.md`. |
+
+Then re-run `tessl skill review --json` and iterate. Score lift per fix is typically 5-15 points.


### PR DESCRIPTION
## Summary

A new `grafana-core/skill-authoring` skill that captures the learnings from Anthropic's published Agent Skills guidance and maps them to the four-dimension rubric the `skill-review` CI gate uses. It's the meta-skill teammates can pull up when:

- Creating a new skill from scratch
- A PR fails the `skill-review` workflow with a score below 75
- A skill's description isn't getting picked up by agents
- An existing skill is technically passing but you want it ≥85

## Sources distilled

- [Anthropic — Agent Skills best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) — the canonical doc
- [anthropics/skills — skill-creator SKILL.md](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md) — the meta-skill Anthropic uses to teach Claude how to write skills (three-level progressive disclosure, "pushy descriptions", anatomy)
- [The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)

Plus practical learnings from this repo's sweep: the routing-document architectural tension surfaced by `grafana-k6/k6-docs` (PR #39 lifted it 72→100 without inlining the bundle), the marketplace-registration step, the hand-craft-vs-`--optimize` decision, and the per-dimension fix patterns observed across 39 skills.

## Structure

The skill follows the three-level progressive-disclosure pattern it itself teaches:

- `SKILL.md` (~170 lines: critical rules, decision tree for new skills, fix patterns for low-scoring ones, anti-patterns summary)
- `references/descriptions.md` — the "pushy description" trigger pattern with strong-vs-weak examples (incl. the actual k6-docs description that lifted to 1.0/1.0)
- `references/rubric.md` — per-dimension scoring (conciseness, actionability, workflow clarity, progressive disclosure) with Anthropic-doc citations + concrete `diff` blocks showing how to fix each
- `references/anatomy.md` — bundle layout, three-level loading model, splitting strategies (by domain / depth / format), and the routing-document special case
- `references/anti-patterns.md` — what NOT to do with concrete wrong-vs-right snippets

## Score

Validated locally with `tessl skill review --json`:

| Dimension | Score |
|---|---:|
| **reviewScore** | **90** |
| Conciseness | 2/3 |
| Actionability | 3/3 |
| Workflow clarity | 3/3 |
| Progressive disclosure | 2/3 |

Both 2/3 dimensions are the architectural-tension case from `references/anatomy.md`: Tessl's content judge doesn't load bundle files, so it slightly penalizes skills with heavy `references/` layouts. The trade-off is fine — this skill is genuinely the right shape for the content, same call we made on `k6-docs`.

Lint: 0 errors, 0 warnings.

## Test plan

- [x] Lint passes (`./scripts/lint-skills.sh skills/grafana-core/skill-authoring`)
- [x] Tessl reviewScore ≥ 75 (got 90)
- [x] Registered in all three `marketplace.json` files
- [ ] CI: `skill-review` + `validate` + `lint-skills` pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)