### PR TITLE
ci: add least-privilege permissions to lint-skills and validate workflows

### DIFF
--- a/.github/workflows/lint-skills.yml
+++ b/.github/workflows/lint-skills.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-skills:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Add an explicit `permissions: contents: read` block to the `lint-skills` and `validate` workflows.

## Why

zizmor's `excessive-permissions` audit flagged both workflows: neither declared a `permissions:` block, so both inherit the organization's default `GITHUB_TOKEN` scope. When the org restricts default token permissions to read-only, workflows without an explicit block can break; conversely, without a block they may run with broader scope than needed.

Both jobs only checkout the repo and run local scripts (`lint-skills.sh` / marketplace validation), so `contents: read` is sufficient.

```
warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/lint-skills.yml
  --> ./.github/workflows/validate.yml
```

## Test plan

- No functional change to job steps; both jobs still checkout + run their scripts.
- zizmor `excessive-permissions` warning clears for both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)