### PR TITLE
feat(skills): add dependency audit skills to grafana-plugins

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -104,7 +104,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, dependency audits, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -118,7 +118,9 @@
       "skills": [
         "./skills/grafana-plugins/plugin-bundle-size",
         "./skills/grafana-plugins/react-19-plugin-migration",
-        "./skills/grafana-plugins/grafana-scenes"
+        "./skills/grafana-plugins/grafana-scenes",
+        "./skills/grafana-plugins/check-npm",
+        "./skills/grafana-plugins/audit-and-reduce-dependencies"
       ]
     },
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -104,7 +104,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, dependency audits, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -118,7 +118,9 @@
       "skills": [
         "./skills/grafana-plugins/plugin-bundle-size",
         "./skills/grafana-plugins/react-19-plugin-migration",
-        "./skills/grafana-plugins/grafana-scenes"
+        "./skills/grafana-plugins/grafana-scenes",
+        "./skills/grafana-plugins/check-npm",
+        "./skills/grafana-plugins/audit-and-reduce-dependencies"
       ]
     },
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -104,7 +104,7 @@
     {
       "name": "grafana-plugins",
       "source": "./",
-      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, dependency audits, and the @grafana/scenes framework",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [
@@ -118,7 +118,9 @@
       "skills": [
         "./skills/grafana-plugins/plugin-bundle-size",
         "./skills/grafana-plugins/react-19-plugin-migration",
-        "./skills/grafana-plugins/grafana-scenes"
+        "./skills/grafana-plugins/grafana-scenes",
+        "./skills/grafana-plugins/check-npm",
+        "./skills/grafana-plugins/audit-and-reduce-dependencies"
       ]
     },
     {

--- a/README.md
+++ b/README.md
@@ -113,13 +113,15 @@ Open-source LGTM observability stack — Loki, Tempo, Prometheus/Mimir, and Pyro
 
 ### grafana-plugins
 
-Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework.
+Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, dependency audits, and the @grafana/scenes framework.
 
 | Skill | Description |
 |-------|-------------|
 | [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size) | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
 | [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13 |
 | [grafana-scenes](skills/grafana-plugins/grafana-scenes) | Build Grafana plugin pages using the @grafana/scenes framework |
+| [check-npm](skills/grafana-plugins/check-npm) | Audit npm, yarn, or pnpm package manager configuration for supply-chain hardening |
+| [audit-and-reduce-dependencies](skills/grafana-plugins/audit-and-reduce-dependencies) | Reduce pnpm dependency footprint — unused deps, deduplication, transitive closure triage |
 
 ### grafana-app-sdk
 

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -5,7 +5,7 @@
   "plugins": [
     {
       "name": "grafana-plugins",
-      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework",
+      "description": "Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, dependency audits, and the @grafana/scenes framework",
       "skills": [
         {
           "name": "plugin-bundle-size",
@@ -24,6 +24,18 @@
           "description": "Build Grafana plugin pages using the @grafana/scenes framework. Use when creating scene pages, adding panels, setting up drilldown navigation, defining variables, or working with SceneApp, EmbeddedScene, SceneQueryRunner, or PanelBuilders.",
           "path": "skills/grafana-plugins/grafana-scenes",
           "tags": ["plugins", "scenes", "react", "grafana-scenes", "drilldown", "panels"]
+        },
+        {
+          "name": "check-npm",
+          "description": "Audit npm, yarn, or pnpm package manager configuration for supply-chain hardening. Use when invoking /check-npm or auditing lifecycle scripts, git dependencies, ignore-scripts, or min-release-age in a Grafana plugin.",
+          "path": "skills/grafana-plugins/check-npm",
+          "tags": ["plugins", "npm", "pnpm", "supply-chain", "security", "dependencies"]
+        },
+        {
+          "name": "audit-and-reduce-dependencies",
+          "description": "Reduce JavaScript dependency footprint with pnpm — remove unused deps, dedupe versions, rank transitive closure, and report Keep/Replace/Remove triage. Use for pnpm dependency cleanup in Grafana plugins.",
+          "path": "skills/grafana-plugins/audit-and-reduce-dependencies",
+          "tags": ["plugins", "pnpm", "dependencies", "supply-chain", "lockfile", "node_modules"]
         }
       ]
     },

--- a/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
+++ b/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
@@ -103,7 +103,7 @@ After a failed freshness check, do not substitute a different version without us
 Collect:
 
 - All `package.json` files and workspace boundaries (`pnpm-workspace.yaml`).
-- `pnpm-lock.yaml` and existing `pnpm-workspace.yaml` security settings (`ignoreScripts`, `frozenLockfile`, `minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps`, `allowBuilds`).
+- `pnpm-lock.yaml`, `pnpm-workspace.yaml` security settings (`minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps`, `allowBuilds`), and install policy in `.npmrc` / CI flags (e.g. `--frozen-lockfile`, `--ignore-scripts`).
 - Direct dependency names by manifest section: `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`.
 - Existing verification commands from scripts, CI, or repo docs.
 - **CI spot-check** (`.github/workflows` or equivalent): installs should use `pnpm install --frozen-lockfile` and script blocking consistent with workspace config. Flag workflows that regenerate lockfiles on every run.

--- a/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
+++ b/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
@@ -152,7 +152,7 @@ Prefer deterministic measurement:
 2. Temporarily remove one direct dependency from the owning manifest.
 3. Run `pnpm install --ignore-scripts` (+ repo flags).
 4. Measure lockfile line/entry reduction and package count reduction.
-5. Revert the temporary removal before measuring the next dependency.
+5. Revert the manifest *and* `pnpm-lock.yaml` (e.g., `git checkout -- <manifest> pnpm-lock.yaml`) before measuring the next dependency.
 
 Use `pnpm why <pkg>` for large transitive packages. Rank by impact and risk, not just raw size.
 

--- a/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
+++ b/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: audit-and-reduce-dependencies
+license: Apache-2.0
+description: >-
+  Reduces JavaScript dependency footprint with pnpm while preserving lockfile,
+  workspace layout, and dependency range style. Runs /check-npm first, then
+  removes unused deps, dedupes versions, ranks transitive closure, and reports
+  Keep/Replace/Remove triage. Use when cleaning up pnpm dependencies, reducing
+  lockfile size, or shrinking node_modules in Grafana plugins; not for Go
+  modules or full GitHub Actions workflow audits.
+---
+
+# Audit and reduce dependencies
+
+Reduce JavaScript dependency footprint. Use **pnpm only**. Preserve the lockfile, workspace layout, and dependency range style unless there is a concrete reason to change them.
+
+For GitHub Actions workflow triage (action choice, permissions, pinning), use a dedicated workflow audit — not the reporting format below (workflow file + step only when the finding is **pnpm install policy**).
+
+## Workflow
+
+0. Hardening gate: run `/check-npm` (read-only). See [check-npm](../check-npm/SKILL.md).
+1. Establish the baseline.
+2. Remove unused direct dependencies.
+3. Deduplicate direct dependency versions in monorepos.
+4. Rank direct dependencies by transitive lockfile closure.
+5. Use closure data to find low-risk minor/patch upgrades.
+6. Use closure data to find trivial dependencies worth inlining.
+7. Check e18e recommendations for replacements/removals.
+8. Reinstall, verify, and report measured impact.
+
+## Step 0: Hardening gate (`/check-npm`)
+
+Run **`/check-npm`** before mutating manifests or lockfiles.
+
+- If any check **FAIL**s: report the table and fix snippets; **do not weaken** `pnpm-workspace.yaml`, `.npmrc`, CI install flags, or Renovate age gates during cleanup.
+- Do not paste full hardening config into this workflow — `/check-npm` owns version thresholds, script policy, git-dep protocols, and min release age.
+- If the user only asked for hardening (not reduction), stop after `/check-npm` unless they also want cleanup.
+
+**pnpm 11+:** script and release-age policy live in `pnpm-workspace.yaml`, not `.npmrc` or `package.json#pnpm` (pnpm 11 no longer reads the `package.json#pnpm` field). Verify each key against the installed pnpm major before suggesting config. Never add unsupported keys. Do not lower an existing `minimumReleaseAge` (or org equivalent) during cleanup.
+
+## Dependency triage
+
+For each non-trivial direct dependency (especially after Steps 4–7), assign one label:
+
+| Label | Meaning |
+|-------|---------|
+| **Keep** | Required; worthwhile transitive cost; well maintained. |
+| **Replace-with-Better** | Required; better-maintained or safer alternative exists. |
+| **Replace-with-Internal** | Required; external risk warrants internal implementation. |
+| **Remove** | Can drop or inline (Step 6). |
+| **Needs-user-review** | Ambiguous usage, policy tradeoff, or change needing human verification. |
+
+**Replacements and new direct deps**
+
+- **No new direct dependencies** (including swaps) without explicit user approval.
+- Prefer **Remove** (inline/native APIs) over **Replace-with-Better** when equivalent.
+- For **Replace-with-Better**: state why (maintenance, security, smaller tree); prefer actively maintained, widely adopted packages from trusted maintainers.
+- Respect repo `minimumReleaseAge` / Renovate gates; command-level 72h freshness is a floor, not permission to bypass stricter config.
+
+## pnpm & supply-chain
+
+Confirm the repo uses pnpm: `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and/or `packageManager` / `devEngines.packageManager.name` set to `pnpm` in root `package.json`. If not on pnpm, stop — do not migrate package managers as part of cleanup.
+
+Respect repo install policy when present (e.g. `pnpm install --frozen-lockfile --ignore-scripts`).
+
+| Action | Command |
+|--------|---------|
+| Install/update lockfile | `pnpm install --ignore-scripts` (+ repo flags, e.g. `--frozen-lockfile`) |
+| Remove direct dependency | `pnpm remove <pkg> --ignore-scripts` |
+| Add/update direct dependency | `pnpm add <pkg>@<version> --ignore-scripts` |
+| Explain dependency | `pnpm why <pkg>` |
+| Dedupe lockfile | `pnpm dedupe` (then `pnpm install --ignore-scripts` if lockfile changed) |
+| Outdated / version info | `pnpm outdated <pkg>` |
+| One-off tools | `pnpm dlx <pkg>@<version> --ignore-scripts` (pin version; prefer `pnpm exec` when in lockfile) |
+
+**Lifecycle scripts:** Always `--ignore-scripts` on `pnpm install`, `pnpm add`, `pnpm remove`, and `pnpm dlx` unless the user explicitly writes **allow scripts** in the same message (state which scripts would run and the risk). If a dependency legitimately needs a build script (native modules, etc.), finish without scripts, then ask whether to run a **specific** manual rebuild (e.g. `pnpm rebuild <pkg>`).
+
+**Freshness check (≥ 72 hours)** — required before any command that adds or upgrades a **named package version** (`pnpm add`, `pnpm dlx` with new/upgraded direct version). **Not required** for plain `pnpm install` / `pnpm remove` with no new package argument.
+
+For each directly named package:
+
+1. `curl -s https://registry.npmjs.org/<package-name>`
+2. Resolve version: pinned `pkg@1.2.3` → that version; range/`latest`/unspecified → `dist-tags.latest`
+3. Read `time["<version>"]`
+4. If published **less than 72 hours ago** → **stop**. Tell the user package, version, and exact age. Suggest an older known-good pin unless they write **override freshness check**.
+5. **`@grafana/*`** scoped packages are **exempt** from the freshness check; `--ignore-scripts` still applies.
+
+After a failed freshness check, do not substitute a different version without user approval.
+
+## Safety rules
+
+- Work in small batches so lockfile diffs remain reviewable.
+- Never trust unused-dependency tools blindly; verify imports, config files, scripts, generated code hooks, framework conventions, plugin names, CLIs, and dynamic imports.
+- You may write scripting and parsing to verify `package.json` and lockfile dependency accounts.
+- Treat `peerDependencies`, `optionalDependencies`, package bin usage, test fixtures, and published package manifests as higher risk.
+- Do not remove or inline dependencies used for security, parsing, crypto, Unicode, URL handling, date/time, i18n, or platform compatibility unless the replacement is proven equivalent.
+- Do not switch package managers, delete `pnpm-lock.yaml`, or rewrite workspace structure as part of cleanup.
+- Treat `pnpm dedupe` as potentially behavior-changing; inspect lockfile diffs and run focused verification before keeping the result.
+- Measure before and after: direct dependency count, lockfile line count or entry count, package count, and estimated `node_modules` size when available.
+
+## Step 1: Baseline
+
+Collect:
+
+- All `package.json` files and workspace boundaries (`pnpm-workspace.yaml`).
+- `pnpm-lock.yaml` and existing `pnpm-workspace.yaml` security settings (`ignoreScripts`, `frozenLockfile`, `minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps`, `allowBuilds`).
+- Direct dependency names by manifest section: `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`.
+- Existing verification commands from scripts, CI, or repo docs.
+- **CI spot-check** (`.github/workflows` or equivalent): installs should use `pnpm install --frozen-lockfile` and script blocking consistent with workspace config. Flag workflows that regenerate lockfiles on every run.
+- **Renovate / Dependabot** (if present): note `minimumReleaseAge` for npm packages; do not reduce it during cleanup.
+
+Record baseline metrics: `git status --short`, `wc -l pnpm-lock.yaml`. If `node_modules` is installed, estimate footprint with platform-appropriate tools. Lockfile reductions are the primary metric — do not depend on `node_modules` being present.
+
+## Step 2: Remove unused direct dependencies
+
+**Unsafe direct dependency protocols** — scan all workspace `package.json` dependency sections. Flag values that are not: semver range, `workspace:`, `patch:`, or `npm:` alias to semver. Flag `git:` / `github:` / tarball URLs / `user/repo` shorthand / `file:` / `link:` / `exec:` / etc. (same allow-list as `/check-npm`). Do not remove flagged entries silently; report for a separate hardening PR unless the user asked to fix them.
+
+Use a static analyzer as a starting point, not as proof (knip, depcheck, or repo-native tooling). Run with pinned `pnpm dlx <tool>@<version> --ignore-scripts` when not installed (freshness-check the pin first).
+
+For each candidate:
+
+- Search code, configs, package scripts, build tooling, tests, and docs for the package name and known import paths.
+- Check whether required by a published package manifest, peer contract, plugin loader, CLI command, or dynamic `require`/`import`.
+- Remove only when no real usage remains.
+- Run `pnpm install --ignore-scripts` (+ repo flags) and focused verification.
+
+If usage is only in a script or config, consider moving between `dependencies` and `devDependencies` instead of removing.
+
+## Step 3: Deduplicate monorepo direct versions
+
+Look for the same direct dependency declared with multiple versions/ranges across package manifests. Use existing policy first: exact pins, caret ranges, catalog/protocol usage, workspace protocol, or central constraints.
+
+- Use `syncpack list-mismatches` or equivalent for discovery.
+- Standardize direct ranges when packages can share the same compatible version.
+- Prefer manifest-level consistency before adding `pnpm.overrides`.
+- Use `pnpm.overrides` only for transitive convergence or security fixes, and document why.
+
+After deduping, run `pnpm install --ignore-scripts` (+ repo flags) and inspect manifest and lockfile diffs. Then consider `pnpm dedupe` — apply carefully; may change transitive resolution.
+
+## Step 4: Rank transitive lockfile closure
+
+For each important direct dependency, estimate closure: transitive lockfile entries reachable from that dependency.
+
+Report both:
+
+- **Total closure**: all packages reachable from the dependency.
+- **Exclusive closure**: packages that disappear if this dependency is removed and are not retained by other direct dependencies.
+
+Prefer deterministic measurement:
+
+1. Save baseline lockfile metrics.
+2. Temporarily remove one direct dependency from the owning manifest.
+3. Run `pnpm install --ignore-scripts` (+ repo flags).
+4. Measure lockfile line/entry reduction and package count reduction.
+5. Revert the temporary removal before measuring the next dependency.
+
+Use `pnpm why <pkg>` for large transitive packages. Rank by impact and risk, not just raw size.
+
+## Step 5: Find low-risk high-impact upgrades
+
+Use closure rankings to target direct dependencies whose newer minor/patch versions reduce transitive dependencies.
+
+For each candidate:
+
+- Check available non-major versions with `pnpm outdated`.
+- Review changelog/release notes for dependency tree changes.
+- Freshness-check the target version, then upgrade one dependency or tight cluster at a time (`pnpm add <pkg>@<version> --ignore-scripts`).
+- Run `pnpm install --ignore-scripts` (+ repo flags) and compare closure metrics.
+- Run focused tests and relevant build/typecheck commands.
+
+Avoid major upgrades unless the user explicitly accepts the migration risk.
+
+## Step 6: Inline trivial usage
+
+Use closure rankings to find direct dependencies with small, obvious usage but large transitive cost.
+
+Inline only when all are true:
+
+- Usage is tiny and easy to fully characterize.
+- Equivalent code is shorter or clearer than retaining the dependency.
+- Behavior is covered by tests or can be covered with small characterization tests.
+- The dependency is not solving cross-platform, security, parsing, Unicode, locale, or spec-compliance edge cases.
+
+Prefer native APIs over new replacement dependencies when the required behavior is simple.
+
+## Step 7: Apply e18e guidance
+
+```bash
+# Pin @e18e/cli@<version> after freshness check; add --ignore-scripts
+pnpm dlx @e18e/cli@<version> analyze --ignore-scripts
+pnpm dlx @e18e/cli@<version> migrate --dry-run --ignore-scripts
+```
+
+Also check https://e18e.dev/docs/replacements/. Treat recommendations as candidates, not mandates; verify bundle/runtime behavior and run tests. Map e18e swaps to **Replace-with-Better** only after user approval.
+
+## Reporting
+
+Summarize outcomes with measured impact:
+
+- `/check-npm` result (PASS/FAIL summary; link fixes if FAIL).
+- Direct dependencies removed or moved.
+- Direct versions deduplicated.
+- Lockfile line/entry reduction.
+- Estimated package or `node_modules` reduction when available.
+- High-impact candidates deferred and why (including replacements awaiting approval).
+- Unsafe protocol / CI / Renovate findings from baseline (if any).
+- Verification commands run and results.
+- Supply-chain: versions freshness-checked (or exempted), `--ignore-scripts` on all installs/adds/dlx.
+
+Call out risk explicitly when a removal depends on static analysis rather than runtime coverage.
+
+### Reporting format
+
+Use for **dependency cleanup findings only** — not GitHub Actions workflow triage.
+
+For each finding:
+
+- **Evidence**: package name and version/range; manifest path and section; supporting signal (import site, `pnpm why`, knip/depcheck hit, closure measurement, `/check-npm` row, or workflow file + step only for **pnpm install policy**).
+- **Decision**: one of **Dependency triage** labels.
+- **Proposed change**: exact manifest/lockfile command or edit. If not applied yet, state that explicitly.
+- **Rationale**: footprint (exclusive/total closure), supply-chain, maintenance, or verification risk.
+- **User review required**: tests/build/typecheck to run; peer/plugin/CLI consumers; published-package or dynamic-import risk; approval before **Replace-with-Better** or any new direct dependency.
+
+Use one block per package (or per protocol/CI finding), not a single-line summary, when the finding is non-trivial.

--- a/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
+++ b/skills/grafana-plugins/audit-and-reduce-dependencies/SKILL.md
@@ -71,9 +71,9 @@ Respect repo install policy when present (e.g. `pnpm install --frozen-lockfile -
 | Explain dependency | `pnpm why <pkg>` |
 | Dedupe lockfile | `pnpm dedupe` (then `pnpm install --ignore-scripts` if lockfile changed) |
 | Outdated / version info | `pnpm outdated <pkg>` |
-| One-off tools | `pnpm dlx <pkg>@<version> --ignore-scripts` (pin version; prefer `pnpm exec` when in lockfile) |
+| One-off tools | `pnpm --config.ignore-scripts=true dlx <pkg>@<version> <args...>` (pin version; prefer `pnpm exec` when in lockfile) |
 
-**Lifecycle scripts:** Always `--ignore-scripts` on `pnpm install`, `pnpm add`, `pnpm remove`, and `pnpm dlx` unless the user explicitly writes **allow scripts** in the same message (state which scripts would run and the risk). If a dependency legitimately needs a build script (native modules, etc.), finish without scripts, then ask whether to run a **specific** manual rebuild (e.g. `pnpm rebuild <pkg>`).
+**Lifecycle scripts:** Always `--ignore-scripts` on `pnpm install`, `pnpm add`, and `pnpm remove` unless the user explicitly writes **allow scripts** in the same message (state which scripts would run and the risk). For `pnpm dlx`, `dlx` does not accept `--ignore-scripts` directly — use `pnpm --config.ignore-scripts=true dlx` (flags after `dlx` are forwarded to the executed binary). If a dependency legitimately needs a build script (native modules, etc.), finish without scripts, then ask whether to run a **specific** manual rebuild (e.g. `pnpm rebuild <pkg>`).
 
 **Freshness check (≥ 72 hours)** — required before any command that adds or upgrades a **named package version** (`pnpm add`, `pnpm dlx` with new/upgraded direct version). **Not required** for plain `pnpm install` / `pnpm remove` with no new package argument.
 
@@ -115,7 +115,7 @@ Record baseline metrics: `git status --short`, `wc -l pnpm-lock.yaml`. If `node_
 
 **Unsafe direct dependency protocols** — scan all workspace `package.json` dependency sections. Flag values that are not: semver range, `workspace:`, `patch:`, or `npm:` alias to semver. Flag `git:` / `github:` / tarball URLs / `user/repo` shorthand / `file:` / `link:` / `exec:` / etc. (same allow-list as `/check-npm`). Do not remove flagged entries silently; report for a separate hardening PR unless the user asked to fix them.
 
-Use a static analyzer as a starting point, not as proof (knip, depcheck, or repo-native tooling). Run with pinned `pnpm dlx <tool>@<version> --ignore-scripts` when not installed (freshness-check the pin first).
+Use a static analyzer as a starting point, not as proof (knip, depcheck, or repo-native tooling). Run with pinned `pnpm --config.ignore-scripts=true dlx <tool>@<version> <args...>` when not installed (freshness-check the pin first).
 
 For each candidate:
 
@@ -186,9 +186,9 @@ Prefer native APIs over new replacement dependencies when the required behavior 
 ## Step 7: Apply e18e guidance
 
 ```bash
-# Pin @e18e/cli@<version> after freshness check; add --ignore-scripts
-pnpm dlx @e18e/cli@<version> analyze --ignore-scripts
-pnpm dlx @e18e/cli@<version> migrate --dry-run --ignore-scripts
+# Pin @e18e/cli@<version> after freshness check; disable scripts on the dlx install
+pnpm --config.ignore-scripts=true dlx @e18e/cli@<version> analyze
+pnpm --config.ignore-scripts=true dlx @e18e/cli@<version> migrate --dry-run
 ```
 
 Also check https://e18e.dev/docs/replacements/. Treat recommendations as candidates, not mandates; verify bundle/runtime behavior and run tests. Map e18e swaps to **Replace-with-Better** only after user approval.
@@ -205,7 +205,7 @@ Summarize outcomes with measured impact:
 - High-impact candidates deferred and why (including replacements awaiting approval).
 - Unsafe protocol / CI / Renovate findings from baseline (if any).
 - Verification commands run and results.
-- Supply-chain: versions freshness-checked (or exempted), `--ignore-scripts` on all installs/adds/dlx.
+- Supply-chain: versions freshness-checked (or exempted), `--ignore-scripts` on all installs/adds, `--config.ignore-scripts=true` on `pnpm dlx`.
 
 Call out risk explicitly when a removal depends on static analysis rather than runtime coverage.
 

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: check-npm
+license: Apache-2.0
+description: >-
+  Audit a JavaScript/TypeScript repo's npm, yarn, or pnpm package manager
+  configuration for supply-chain hardening. Use when the user invokes /check-npm
+  or asks to audit package manager security, lifecycle scripts, git dependencies,
+  ignore-scripts, min-release-age, or similar hardening checks in a Grafana plugin
+  or JS/TS project.
+---
+
+# npm / yarn / pnpm Supply-Chain Hardening Audit
+
+Read-only audit of the current workspace root against four hardening criteria. Do NOT modify any files.
+
+## Step 0 — Detect package manager
+
+If there is no `package.json` at the workspace root, stop and tell the user this skill only applies to JS/TS repos.
+
+Otherwise, determine the package manager in priority order:
+
+1. `packageManager` field in `package.json` (e.g. `"yarn@4.14.0"` → yarn)
+2. Lockfile presence: `yarn.lock` → yarn, `package-lock.json` → npm, `pnpm-lock.yaml` → pnpm
+3. Default to npm
+
+State which one the repo uses. The remaining checks key off this.
+
+## Step 1 — Tool version
+
+Run the version command for the detected manager:
+
+- **npm**: `npm --version` → required ≥ **11.15.0** (`--allow-git` shipped in 11.15.0; `min-release-age` shipped in 11.10.0)
+- **yarn**: `yarn --version` → required ≥ **4.14.0** (`approvedGitRepositories` shipped in 4.14.0)
+- **pnpm**: `pnpm --version` → required ≥ **11.0.0** (pnpm 11 turns `minimumReleaseAge`, `strictDepBuilds`, and `blockExoticSubdeps` on by default)
+
+If `packageManager` is pinned in `package.json`, verify the pinned version meets the threshold.
+
+Use semver comparison, not string compare.
+
+## Step 2 — Lifecycle scripts disabled
+
+Where each manager looks for the setting depends on its major version:
+
+- **yarn**: read `.yarnrc.yml` at workspace root.
+  - PASS if `enableScripts: false` is set explicitly, OR if `.yarnrc.yml` is absent / does not mention `enableScripts` (yarn 4 defaults to `false`).
+  - FAIL only if `enableScripts: true` is set.
+- **npm**: read `.npmrc` at workspace root.
+  - PASS if it contains `ignore-scripts=true`.
+  - FAIL otherwise (npm defaults to RUN scripts).
+- **pnpm ≥ 11**: read `pnpm-workspace.yaml` at the workspace root. On pnpm 11+, pnpm no longer reads build-script settings from `package.json#pnpm` or non-auth `.npmrc` entries — those are silently ignored.
+  - PASS if `strictDepBuilds` is unset or `true` (default `true` since pnpm 11), AND `dangerouslyAllowAllBuilds` is unset or `false` (default `false`).
+  - FAIL if `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true`.
+  - If `allowBuilds` is set, list every key whose value is `true` in the detail column — those packages can still execute scripts.
+- **pnpm 10.x** (legacy): read `.npmrc`, `pnpm-workspace.yaml`, and the `pnpm` field in root `package.json` (pnpm 10 still reads `package.json#pnpm`).
+  - PASS if `.npmrc` contains `ignore-scripts=true`, OR `pnpm-workspace.yaml` has `strictDepBuilds: true` (default since pnpm 10.3).
+  - FAIL if neither holds, or if `ignore-scripts=false` is set, or `strictDepBuilds: false`.
+  - If `onlyBuiltDependencies` is set, list those packages — they're the build-script allow-list on pnpm 10.
+- **pnpm < 10**: read `.npmrc`.
+  - PASS only if `ignore-scripts=true`.
+  - FAIL otherwise.
+
+## Step 3 — Unsafe dependency protocols
+
+Yarn (and to a lesser extent npm) supports many ways to declare a dependency beyond a plain semver range. Several of them resolve to arbitrary remote sources (git, tarball URLs, exec scripts, …) that bypass the registry and the min-release-age gate.
+
+### Allow-list
+
+The only dependency protocols considered safe are:
+
+- a valid **semver range** (e.g. `^1.2.3`, `~1.0`, `1.x`, `*`, exact pin `1.2.3`)
+- `workspace:` (e.g. `workspace:^`, `workspace:*`)
+- `patch:` (e.g. `patch:left-pad@1.0.0#~/patches/left-pad.patch`)
+- `npm:` aliases that themselves resolve to a semver range (e.g. `npm:lodash@^4`)
+
+Anything else — including yarn's bare GitHub shorthand `user/repo` or `user/repo#commit-ish` (which silently resolves to a git dep, even with no `git`/`github:` prefix) — is flagged. See <https://yarnpkg.com/protocols> for the full list of yarn protocols.
+
+### Per-manager registry config
+
+- **npm**: read `.npmrc`.
+  - PASS if `allow-git=none` (or `allow-git=root`) is set.
+  - FAIL if missing (default is `all`, which allows arbitrary git deps) or if `allow-git=all`.
+  - Note: `--allow-git` was added in npm 11.15.0. If detected npm is < 11.15.0, the `.npmrc` setting is not enforced — call this out.
+- **yarn**: read `.yarnrc.yml`. There are two valid hardened postures — pick the one the repo's `.yarnrc.yml` documents (look for a comment near the key) and audit against that:
+  - **Posture A — empty allow-list:** PASS if `approvedGitRepositories: []` (blocks all git deps at the resolver). PASS if every entry is scoped to the `grafana` GitHub org (Grafana convention; entries should be listed once per normalized URL form — `https://github.com/grafana/*` and `ssh://git@github.com/grafana/*` and `git@github.com:grafana/*` are three different patterns even though they reference the same repos). FAIL if any entry is scoped outside the `grafana` org — list the offending patterns.
+  - **Posture B — deliberately omitted:** some teams (e.g. grafana/grafana itself) treat the key as a footgun because a future contributor can broaden it. In that case the `.yarnrc.yml` should carry an explicit "do not add `approvedGitRepositories`" comment, and the repo relies on the `package.json` scan below as the sole git-dep gate.
+  - **FAIL only if** `approvedGitRepositories:` is missing *and* the file has no policy comment forbidding it *and* the `package.json` scan in the next section finds any unsafe entry — in that case yarn would actually install the offending dep because it falls back to pre-4.14 behavior. If the scan is clean, PASS with detail `no allow-list; scan clean`.
+- **pnpm ≥ 11**: read `pnpm-workspace.yaml`.
+  - PASS if `blockExoticSubdeps` is unset or `true` (default `true` since pnpm 11).
+  - FAIL if `blockExoticSubdeps: false`.
+- **pnpm 10.x**: read `pnpm-workspace.yaml` and root `package.json#pnpm`.
+  - PASS if `blockExoticSubdeps: true`.
+  - FAIL if unset (default `false` on pnpm 10) or `blockExoticSubdeps: false`.
+
+### Scan workspace `package.json` files
+
+For **all package managers**, scan the root `package.json` **and every workspace member** `package.json` (discover members from `pnpm-workspace.yaml`, npm/yarn `workspaces`, or `lerna.json` / `rush.json` when present). For each file, scan `dependencies` / `devDependencies` / `optionalDependencies` / `peerDependencies`. List every entry whose value is **not** on the allow-list, formatted as:
+
+    path/to/package.json → name → value (protocol)
+
+Detect protocols by matching, in order:
+
+1. Explicit `<scheme>:` prefix (`git:`, `git+https:`, `git+ssh:`, `github:`, `gitlab:`, `bitbucket:`, `link:`, `portal:`, `file:`, `exec:`, `jsr:`, …)
+2. `git@…` SSH-style URLs
+3. Plain URLs starting with `http://`, `https://` (tarball)
+4. Bare `user/repo` or `user/repo#…` (yarn GitHub shorthand, resolves to git)
+5. If none of the above match and the string is not a valid semver range, flag as `(unknown)`.
+
+Any entry that matches 1–5 would be blocked under `allow-git=none` (npm) or rejected if not in `approvedGitRepositories` (yarn).
+
+## Step 4 — Minimum release age ≥ 3 days
+
+Units differ per manager — **npm uses days (integer), yarn and pnpm use minutes (integer)**. 3 days = 4320 minutes.
+
+- **npm**: read `.npmrc`.
+  - PASS if `min-release-age` is set to an integer ≥ `3`.
+  - **FAIL** if missing. `min-release-age` was added in npm 11.10.0 but ships **OFF** by default (`null`) — an unset value means no release-age gate, not a default 3-day window.
+  - If detected npm is < 11.10.0, also recommend upgrading.
+- **yarn**: read `.yarnrc.yml`. The only key is `npmMinimalAgeGate:` (added in yarn 4.10 — confirmed via `yarn config get npmMinimalAgeGate`; the key `npmMinimumReleaseAge` does not exist in yarn 4.x).
+  - PASS if `npmMinimalAgeGate:` is set to a value equivalent to ≥ 3 days. Both numeric minutes (`4320`) and duration strings (`"3d"`, `"72h"`) are accepted by yarn — convert before comparing.
+  - FAIL if the key is missing, or if the resolved value is below the threshold. Default on yarn 4.x is `0` (gate inactive — `yarn config get` returns `0` when the key is unset), so a missing line is genuinely unprotected, not a hidden default.
+  - If `npmPreapprovedPackages:` is set, list the exempted patterns in the detail column — those packages bypass the age gate (a controlled exception, typically used for first-party `@org/*` packages).
+- **pnpm ≥ 11**: read `pnpm-workspace.yaml` at the workspace root. `.npmrc` entries for this setting are ignored on pnpm 11; `package.json#pnpm` is not read on pnpm 11+.
+  - PASS if `minimumReleaseAge:` is set to an integer ≥ `4320`.
+  - **FAIL** if `minimumReleaseAge` is unset or below `4320`. pnpm 11 defaults to `1440` (1 day) when unset — below the 3-day bar. Recommend setting `minimumReleaseAge: 4320` explicitly.
+  - Also flag `minimumReleaseAgeStrict: false` if set — without strict mode pnpm falls back to immature versions when no mature one satisfies the range.
+- **pnpm 10.x**: read `.npmrc`, `pnpm-workspace.yaml`, and root `package.json#pnpm`.
+  - PASS if either contains `minimum-release-age` / `minimumReleaseAge` ≥ `4320`.
+  - FAIL otherwise (pnpm 10 default is `0`).
+- **pnpm < 10**: setting not available. FAIL with a recommendation to upgrade.
+
+## Step 5 — Report
+
+Print a single markdown table:
+
+| # | Check | Status | Detail |
+|---|---|---|---|
+| 0 | Package manager | (npm / yarn / pnpm) | version: x.y.z (pinned: y.y.y) |
+| 1 | Tool version ≥ threshold | PASS / FAIL | `actual` vs `required` |
+| 2 | Scripts disabled | PASS / FAIL | config line found, "missing", or `default applies (pnpm 11)` |
+| 3 | Unsafe dep protocols | PASS / FAIL | registry config state (allow-list / "deliberately omitted" / "missing"), and list of flagged `package.json` entries |
+| 4 | Min release age ≥ 3 days | PASS / FAIL | config line + value; for pnpm 11 unset default (`1440 min`) report FAIL |
+
+Use `PASS` / `FAIL` only — no emojis. Row 0 reports the package manager name and version, not a status.
+
+Below the table, for every FAIL, give exactly one fix snippet the user can paste.
+
+**npm tool version** → upgrade npm (example):
+
+    npm install -g npm@11.15.0
+
+**yarn tool version** → set Yarn to a supported version (do NOT route through Corepack):
+
+    yarn set version stable
+
+**pnpm tool version** → upgrade pnpm (example):
+
+    npm install -g pnpm@11
+
+**npm scripts disabled** → add to `.npmrc`:
+
+    ignore-scripts=true
+
+**pnpm scripts disabled (v11)** → add to `pnpm-workspace.yaml` (do not put this in `.npmrc` on v11 — it's ignored):
+
+    strictDepBuilds: true
+    dangerouslyAllowAllBuilds: false
+
+**pnpm scripts disabled (v10)** → add to `.npmrc`:
+
+    ignore-scripts=true
+
+**yarn scripts disabled** (only if explicitly `true`) → run:
+
+    yarn config set enableScripts false
+
+**npm unsafe dep protocols** → add to `.npmrc` and remove the offending entries from `package.json`:
+
+    allow-git=none
+
+**yarn unsafe dep protocols** → either rewrite the offending entries to semver/`workspace:`/`patch:`, or explicitly allow internal repos by adding to `.yarnrc.yml`. Use an empty list (`approvedGitRepositories: []`) to block all git deps outright:
+
+    approvedGitRepositories:
+      - "https://github.com/grafana/*"
+      - "ssh://git@github.com/grafana/*"
+      - "git@github.com:grafana/*"
+
+**npm min release age** → add to `.npmrc` (value is **days as an integer**):
+
+    min-release-age=3
+
+**pnpm min release age (v11, unset or < 4320)** → add to `pnpm-workspace.yaml` (value is **minutes**):
+
+    minimumReleaseAge: 4320
+
+**pnpm exotic deps (v11)** → ensure `pnpm-workspace.yaml` does not disable blocking:
+
+    blockExoticSubdeps: true
+
+**pnpm min release age (v10)** → add to `.npmrc` (value is **minutes**):
+
+    minimum-release-age=4320
+
+**yarn min release age** → in `.yarnrc.yml`. The only valid key is `npmMinimalAgeGate` (yarn ≥ 4.10). On yarn < 4.10 there is no release-age gate at all — upgrade yarn first via `yarn set version stable`. Accepts numeric minutes or duration strings:
+
+    npmMinimalAgeGate: 4320  # or "3d"
+
+If everything PASSes, finish with "All checks passed." and stop.
+
+## Constraints
+
+- Read manager config at the workspace root (`.npmrc`, `.yarnrc.yml`, `pnpm-workspace.yaml`). For the dependency-protocol scan, also read every workspace member `package.json` (see Step 3).
+- Do NOT modify any files. This is a read-only audit.
+- Be concise. The whole report should fit in one screen.

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -80,6 +80,7 @@ Scan workspace `package.json` files (`dependencies`, `devDependencies`, `optiona
 | npm | `allow-git=none` or `root` | missing or `all` |
 | yarn | `approvedGitRepositories: []` or grafana-scoped list, or omitted with policy comment + clean scan | unsafe entries or broad allow-list |
 | pnpm ≥ 11 | `blockExoticSubdeps` unset/`true` | `false` |
+| pnpm 10.x | `blockExoticSubdeps: true` | unset (default `false`) or `false` |
 
 Protocol detection order and yarn posture details: [references/protocols.md](references/protocols.md).
 

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -88,7 +88,7 @@ Protocol detection order and yarn posture details: [references/protocols.md](ref
 3 days = 4320 minutes. npm uses **days**; yarn and pnpm use **minutes**.
 
 ```bash
-grep -E '^min-release-age=' .npmrc 2>/dev/null
+grep -E '^min(imum)?-release-age=' .npmrc 2>/dev/null
 grep -E 'npmMinimalAgeGate:' .yarnrc.yml 2>/dev/null
 grep -E 'minimumReleaseAge:|minimumReleaseAgeStrict:' pnpm-workspace.yaml 2>/dev/null
 ```

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -128,6 +128,7 @@ min-release-age=3
 # pnpm 11 — pnpm-workspace.yaml
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
+allowBuilds: []
 minimumReleaseAge: 4320
 blockExoticSubdeps: true
 ```

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -1,213 +1,143 @@
 ---
 name: check-npm
 license: Apache-2.0
+disable-model-invocation: true
 description: >-
-  Audit a JavaScript/TypeScript repo's npm, yarn, or pnpm package manager
-  configuration for supply-chain hardening. Use when the user invokes /check-npm
-  or asks to audit package manager security, lifecycle scripts, git dependencies,
-  ignore-scripts, min-release-age, or similar hardening checks in a Grafana plugin
-  or JS/TS project.
+  Audit a JavaScript/TypeScript repo's npm, yarn, or pnpm configuration for
+  supply-chain hardening: tool version, lifecycle scripts, unsafe dependency
+  protocols, and minimum release age ≥3 days. Use when the user invokes
+  /check-npm or asks to audit package manager security, lifecycle scripts, git
+  dependencies, ignore-scripts, min-release-age, allow-git,
+  approvedGitRepositories, strictDepBuilds, or blockExoticSubdeps in a Grafana
+  plugin or JS/TS project.
 ---
 
-# npm / yarn / pnpm Supply-Chain Hardening Audit
+# npm / yarn / pnpm supply-chain audit
 
-Read-only audit of the current workspace root against four hardening criteria. Do NOT modify any files.
+Read-only audit of the workspace root. Do not modify any files.
 
-## Step 0 — Detect package manager
+## 0. Detect package manager
 
-If there is no `package.json` at the workspace root, stop and tell the user this skill only applies to JS/TS repos.
+```bash
+test -f package.json || echo "STOP: no package.json at workspace root"
+jq -r '.packageManager // "unset"' package.json
+ls -1 yarn.lock package-lock.json pnpm-lock.yaml 2>/dev/null
+```
 
-Otherwise, determine the package manager in priority order:
+If no `package.json`, stop. Priority: `packageManager` → lockfile → default npm.
 
-1. `packageManager` field in `package.json` (e.g. `"yarn@4.14.0"` → yarn)
-2. Lockfile presence: `yarn.lock` → yarn, `package-lock.json` → npm, `pnpm-lock.yaml` → pnpm
-3. Default to npm
+## 1. Tool version
 
-State which one the repo uses. The remaining checks key off this.
+```bash
+npm --version    # required ≥ 11.15.0
+yarn --version   # required ≥ 4.14.0
+pnpm --version   # required ≥ 11.0.0
+```
 
-## Step 1 — Tool version
+Use semver comparison. Verify pinned `packageManager` meets threshold.
 
-Run the version command for the detected manager:
+| Manager | Minimum |
+|---------|---------|
+| npm | 11.15.0 |
+| yarn | 4.14.0 |
+| pnpm | 11.0.0 |
 
-- **npm**: `npm --version` → required ≥ **11.15.0** (`--allow-git` shipped in 11.15.0; `min-release-age` shipped in 11.10.0)
-- **yarn**: `yarn --version` → required ≥ **4.14.0** (`approvedGitRepositories` shipped in 4.14.0)
-- **pnpm**: `pnpm --version` → required ≥ **11.0.0** (pnpm 11 turns `minimumReleaseAge`, `strictDepBuilds`, and `blockExoticSubdeps` on by default)
+## 2. Lifecycle scripts disabled
 
-If `packageManager` is pinned in `package.json`, verify the pinned version meets the threshold.
+```bash
+grep -E '^ignore-scripts=' .npmrc 2>/dev/null
+grep -E 'enableScripts:' .yarnrc.yml 2>/dev/null
+grep -E 'strictDepBuilds:|dangerouslyAllowAllBuilds:|allowBuilds:' pnpm-workspace.yaml 2>/dev/null
+```
 
-Use semver comparison, not string compare.
+| Manager | PASS | FAIL |
+|---------|------|------|
+| npm | `.npmrc` has `ignore-scripts=true` | missing or `false` |
+| yarn | `enableScripts: false` or key absent | `enableScripts: true` |
+| pnpm ≥ 11 | `strictDepBuilds` unset/`true`, `dangerouslyAllowAllBuilds` unset/`false` | `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true` |
+| pnpm 10 | `.npmrc` `ignore-scripts=true` OR `strictDepBuilds: true` | neither |
 
-## Step 2 — Lifecycle scripts disabled
+pnpm 11+ ignores script settings in `.npmrc` and `package.json#pnpm`. pnpm 10 / yarn edge cases: [references/managers.md](references/managers.md).
 
-Where each manager looks for the setting depends on its major version:
+## 3. Unsafe dependency protocols
 
-- **yarn**: read `.yarnrc.yml` at workspace root.
-  - PASS if `enableScripts: false` is set explicitly, OR if `.yarnrc.yml` is absent / does not mention `enableScripts` (yarn 4 defaults to `false`).
-  - FAIL only if `enableScripts: true` is set.
-- **npm**: read `.npmrc` at workspace root.
-  - PASS if it contains `ignore-scripts=true`.
-  - FAIL otherwise (npm defaults to RUN scripts).
-- **pnpm ≥ 11**: read `pnpm-workspace.yaml` at the workspace root. On pnpm 11+, pnpm no longer reads build-script settings from `package.json#pnpm` or non-auth `.npmrc` entries — those are silently ignored.
-  - PASS if `strictDepBuilds` is unset or `true` (default `true` since pnpm 11), AND `dangerouslyAllowAllBuilds` is unset or `false` (default `false`).
-  - FAIL if `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true`.
-  - If `allowBuilds` is set, list every key whose value is `true` in the detail column — those packages can still execute scripts.
-- **pnpm 10.x** (legacy): read `.npmrc`, `pnpm-workspace.yaml`, and the `pnpm` field in root `package.json` (pnpm 10 still reads `package.json#pnpm`).
-  - PASS if `.npmrc` contains `ignore-scripts=true`, OR `pnpm-workspace.yaml` has `strictDepBuilds: true` (default since pnpm 10.3).
-  - FAIL if neither holds, or if `ignore-scripts=false` is set, or `strictDepBuilds: false`.
-  - If `onlyBuiltDependencies` is set, list those packages — they're the build-script allow-list on pnpm 10.
-- **pnpm < 10**: read `.npmrc`.
-  - PASS only if `ignore-scripts=true`.
-  - FAIL otherwise.
+Registry:
 
-## Step 3 — Unsafe dependency protocols
+```bash
+grep -E '^allow-git=' .npmrc 2>/dev/null
+grep -E 'approvedGitRepositories:' .yarnrc.yml 2>/dev/null
+grep -E 'blockExoticSubdeps:' pnpm-workspace.yaml 2>/dev/null
+```
 
-Yarn (and to a lesser extent npm) supports many ways to declare a dependency beyond a plain semver range. Several of them resolve to arbitrary remote sources (git, tarball URLs, exec scripts, …) that bypass the registry and the min-release-age gate.
+Scan all workspace `package.json` files (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`):
 
-### Allow-list
+```bash
+find . -name package.json -not -path '*/node_modules/*' | head -50
+```
 
-The only dependency protocols considered safe are:
+**Safe values only:** semver range, `workspace:`, `patch:`, `npm:` alias to semver. Flag everything else (git URLs, tarballs, `user/repo` shorthand, `file:`, `link:`, `exec:`, …) as `path → name → value (protocol)`.
 
-- a valid **semver range** (e.g. `^1.2.3`, `~1.0`, `1.x`, `*`, exact pin `1.2.3`)
-- `workspace:` (e.g. `workspace:^`, `workspace:*`)
-- `patch:` (e.g. `patch:left-pad@1.0.0#~/patches/left-pad.patch`)
-- `npm:` aliases that themselves resolve to a semver range (e.g. `npm:lodash@^4`)
+| Manager | PASS | FAIL |
+|---------|------|------|
+| npm | `allow-git=none` or `root` | missing or `all` |
+| yarn | `approvedGitRepositories: []` or grafana-scoped list, or omitted with policy comment + clean scan | unsafe entries or broad allow-list |
+| pnpm ≥ 11 | `blockExoticSubdeps` unset/`true` | `false` |
 
-Anything else — including yarn's bare GitHub shorthand `user/repo` or `user/repo#commit-ish` (which silently resolves to a git dep, even with no `git`/`github:` prefix) — is flagged. See <https://yarnpkg.com/protocols> for the full list of yarn protocols.
+Protocol detection order and yarn posture details: [references/protocols.md](references/protocols.md).
 
-### Per-manager registry config
+## 4. Minimum release age ≥ 3 days
 
-- **npm**: read `.npmrc`.
-  - PASS if `allow-git=none` (or `allow-git=root`) is set.
-  - FAIL if missing (default is `all`, which allows arbitrary git deps) or if `allow-git=all`.
-  - Note: `--allow-git` was added in npm 11.15.0. If detected npm is < 11.15.0, the `.npmrc` setting is not enforced — call this out.
-- **yarn**: read `.yarnrc.yml`. There are two valid hardened postures — pick the one the repo's `.yarnrc.yml` documents (look for a comment near the key) and audit against that:
-  - **Posture A — empty allow-list:** PASS if `approvedGitRepositories: []` (blocks all git deps at the resolver). PASS if every entry is scoped to the `grafana` GitHub org (Grafana convention; entries should be listed once per normalized URL form — `https://github.com/grafana/*` and `ssh://git@github.com/grafana/*` and `git@github.com:grafana/*` are three different patterns even though they reference the same repos). FAIL if any entry is scoped outside the `grafana` org — list the offending patterns.
-  - **Posture B — deliberately omitted:** some teams (e.g. grafana/grafana itself) treat the key as a footgun because a future contributor can broaden it. In that case the `.yarnrc.yml` should carry an explicit "do not add `approvedGitRepositories`" comment, and the repo relies on the `package.json` scan below as the sole git-dep gate.
-  - **FAIL only if** `approvedGitRepositories:` is missing *and* the file has no policy comment forbidding it *and* the `package.json` scan in the next section finds any unsafe entry — in that case yarn would actually install the offending dep because it falls back to pre-4.14 behavior. If the scan is clean, PASS with detail `no allow-list; scan clean`.
-- **pnpm ≥ 11**: read `pnpm-workspace.yaml`.
-  - PASS if `blockExoticSubdeps` is unset or `true` (default `true` since pnpm 11).
-  - FAIL if `blockExoticSubdeps: false`.
-- **pnpm 10.x**: read `pnpm-workspace.yaml` and root `package.json#pnpm`.
-  - PASS if `blockExoticSubdeps: true`.
-  - FAIL if unset (default `false` on pnpm 10) or `blockExoticSubdeps: false`.
+3 days = 4320 minutes. npm uses **days**; yarn and pnpm use **minutes**.
 
-### Scan workspace `package.json` files
+```bash
+grep -E '^min-release-age=' .npmrc 2>/dev/null
+grep -E 'npmMinimalAgeGate:' .yarnrc.yml 2>/dev/null
+grep -E 'minimumReleaseAge:|minimumReleaseAgeStrict:' pnpm-workspace.yaml 2>/dev/null
+```
 
-For **all package managers**, scan the root `package.json` **and every workspace member** `package.json` (discover members from `pnpm-workspace.yaml`, npm/yarn `workspaces`, or `lerna.json` / `rush.json` when present). For each file, scan `dependencies` / `devDependencies` / `optionalDependencies` / `peerDependencies`. List every entry whose value is **not** on the allow-list, formatted as:
+| Manager | PASS | FAIL |
+|---------|------|------|
+| npm | `min-release-age` ≥ `3` | missing |
+| yarn | `npmMinimalAgeGate` ≥ 4320 min | missing or below |
+| pnpm ≥ 11 | `minimumReleaseAge` ≥ `4320` | unset (default `1440`) or below |
+| pnpm 10 | `minimum-release-age` / `minimumReleaseAge` ≥ `4320` | missing |
 
-    path/to/package.json → name → value (protocol)
+Flag `minimumReleaseAgeStrict: false` on pnpm 11.
 
-Detect protocols by matching, in order:
-
-1. Explicit `<scheme>:` prefix (`git:`, `git+https:`, `git+ssh:`, `github:`, `gitlab:`, `bitbucket:`, `link:`, `portal:`, `file:`, `exec:`, `jsr:`, …)
-2. `git@…` SSH-style URLs
-3. Plain URLs starting with `http://`, `https://` (tarball)
-4. Bare `user/repo` or `user/repo#…` (yarn GitHub shorthand, resolves to git)
-5. If none of the above match and the string is not a valid semver range, flag as `(unknown)`.
-
-Any entry that matches 1–5 would be blocked under `allow-git=none` (npm) or rejected if not in `approvedGitRepositories` (yarn).
-
-## Step 4 — Minimum release age ≥ 3 days
-
-Units differ per manager — **npm uses days (integer), yarn and pnpm use minutes (integer)**. 3 days = 4320 minutes.
-
-- **npm**: read `.npmrc`.
-  - PASS if `min-release-age` is set to an integer ≥ `3`.
-  - **FAIL** if missing. `min-release-age` was added in npm 11.10.0 but ships **OFF** by default (`null`) — an unset value means no release-age gate, not a default 3-day window.
-  - If detected npm is < 11.10.0, also recommend upgrading.
-- **yarn**: read `.yarnrc.yml`. The only key is `npmMinimalAgeGate:` (added in yarn 4.10 — confirmed via `yarn config get npmMinimalAgeGate`; the key `npmMinimumReleaseAge` does not exist in yarn 4.x).
-  - PASS if `npmMinimalAgeGate:` is set to a value equivalent to ≥ 3 days. Both numeric minutes (`4320`) and duration strings (`"3d"`, `"72h"`) are accepted by yarn — convert before comparing.
-  - FAIL if the key is missing, or if the resolved value is below the threshold. Default on yarn 4.x is `0` (gate inactive — `yarn config get` returns `0` when the key is unset), so a missing line is genuinely unprotected, not a hidden default.
-  - If `npmPreapprovedPackages:` is set, list the exempted patterns in the detail column — those packages bypass the age gate (a controlled exception, typically used for first-party `@org/*` packages).
-- **pnpm ≥ 11**: read `pnpm-workspace.yaml` at the workspace root. `.npmrc` entries for this setting are ignored on pnpm 11; `package.json#pnpm` is not read on pnpm 11+.
-  - PASS if `minimumReleaseAge:` is set to an integer ≥ `4320`.
-  - **FAIL** if `minimumReleaseAge` is unset or below `4320`. pnpm 11 defaults to `1440` (1 day) when unset — below the 3-day bar. Recommend setting `minimumReleaseAge: 4320` explicitly.
-  - Also flag `minimumReleaseAgeStrict: false` if set — without strict mode pnpm falls back to immature versions when no mature one satisfies the range.
-- **pnpm 10.x**: read `.npmrc`, `pnpm-workspace.yaml`, and root `package.json#pnpm`.
-  - PASS if either contains `minimum-release-age` / `minimumReleaseAge` ≥ `4320`.
-  - FAIL otherwise (pnpm 10 default is `0`).
-- **pnpm < 10**: setting not available. FAIL with a recommendation to upgrade.
-
-## Step 5 — Report
-
-Print a single markdown table:
+## 5. Report
 
 | # | Check | Status | Detail |
 |---|---|---|---|
-| 0 | Package manager | (npm / yarn / pnpm) | version: x.y.z (pinned: y.y.y) |
+| 0 | Package manager | (npm / yarn / pnpm) | version: x.y.z (pinned: y.y.y if set) |
 | 1 | Tool version ≥ threshold | PASS / FAIL | `actual` vs `required` |
-| 2 | Scripts disabled | PASS / FAIL | config line found, "missing", or `default applies (pnpm 11)` |
-| 3 | Unsafe dep protocols | PASS / FAIL | registry config state (allow-list / "deliberately omitted" / "missing"), and list of flagged `package.json` entries |
-| 4 | Min release age ≥ 3 days | PASS / FAIL | config line + value; for pnpm 11 unset default (`1440 min`) report FAIL |
+| 2 | Scripts disabled | PASS / FAIL | config line or "missing" |
+| 3 | Unsafe dep protocols | PASS / FAIL | registry state + flagged entries |
+| 4 | Min release age ≥ 3 days | PASS / FAIL | config + value |
 
-Use `PASS` / `FAIL` only — no emojis. Row 0 reports the package manager name and version, not a status.
+Use `PASS` / `FAIL` only — no emojis.
 
-Below the table, for every FAIL, give exactly one fix snippet the user can paste.
+For each FAIL, one paste-ready fix:
 
-**npm tool version** → upgrade npm (example):
+```ini
+# npm — .npmrc
+ignore-scripts=true
+allow-git=none
+min-release-age=3
+```
 
-    npm install -g npm@11.15.0
+```yaml
+# pnpm 11 — pnpm-workspace.yaml
+strictDepBuilds: true
+dangerouslyAllowAllBuilds: false
+minimumReleaseAge: 4320
+blockExoticSubdeps: true
+```
 
-**yarn tool version** → set Yarn to a supported version (do NOT route through Corepack):
+```yaml
+# yarn — .yarnrc.yml
+npmMinimalAgeGate: 4320
+```
 
-    yarn set version stable
+More fixes (tool upgrades, yarn git allow-list, pnpm 10): [references/fix-snippets.md](references/fix-snippets.md).
 
-**pnpm tool version** → upgrade pnpm (example):
-
-    npm install -g pnpm@11
-
-**npm scripts disabled** → add to `.npmrc`:
-
-    ignore-scripts=true
-
-**pnpm scripts disabled (v11)** → add to `pnpm-workspace.yaml` (do not put this in `.npmrc` on v11 — it's ignored):
-
-    strictDepBuilds: true
-    dangerouslyAllowAllBuilds: false
-
-**pnpm scripts disabled (v10)** → add to `.npmrc`:
-
-    ignore-scripts=true
-
-**yarn scripts disabled** (only if explicitly `true`) → run:
-
-    yarn config set enableScripts false
-
-**npm unsafe dep protocols** → add to `.npmrc` and remove the offending entries from `package.json`:
-
-    allow-git=none
-
-**yarn unsafe dep protocols** → either rewrite the offending entries to semver/`workspace:`/`patch:`, or explicitly allow internal repos by adding to `.yarnrc.yml`. Use an empty list (`approvedGitRepositories: []`) to block all git deps outright:
-
-    approvedGitRepositories:
-      - "https://github.com/grafana/*"
-      - "ssh://git@github.com/grafana/*"
-      - "git@github.com:grafana/*"
-
-**npm min release age** → add to `.npmrc` (value is **days as an integer**):
-
-    min-release-age=3
-
-**pnpm min release age (v11, unset or < 4320)** → add to `pnpm-workspace.yaml` (value is **minutes**):
-
-    minimumReleaseAge: 4320
-
-**pnpm exotic deps (v11)** → ensure `pnpm-workspace.yaml` does not disable blocking:
-
-    blockExoticSubdeps: true
-
-**pnpm min release age (v10)** → add to `.npmrc` (value is **minutes**):
-
-    minimum-release-age=4320
-
-**yarn min release age** → in `.yarnrc.yml`. The only valid key is `npmMinimalAgeGate` (yarn ≥ 4.10). On yarn < 4.10 there is no release-age gate at all — upgrade yarn first via `yarn set version stable`. Accepts numeric minutes or duration strings:
-
-    npmMinimalAgeGate: 4320  # or "3d"
-
-If everything PASSes, finish with "All checks passed." and stop.
-
-## Constraints
-
-- Read manager config at the workspace root (`.npmrc`, `.yarnrc.yml`, `pnpm-workspace.yaml`). For the dependency-protocol scan, also read every workspace member `package.json` (see Step 3).
-- Do NOT modify any files. This is a read-only audit.
-- Be concise. The whole report should fit in one screen.
+If all PASS: "All checks passed." and stop.

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -19,7 +19,7 @@ Read-only audit of the workspace root. Do not modify any files.
 ## 0. Detect package manager
 
 ```bash
-test -f package.json || echo "STOP: no package.json at workspace root"
+test -f package.json || { echo "STOP: no package.json at workspace root"; exit 1; }
 jq -r '.packageManager // "unset"' package.json
 ls -1 yarn.lock package-lock.json pnpm-lock.yaml 2>/dev/null
 ```

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-npm
 license: Apache-2.0
-disable-model-invocation: true
+disable-model-invocation: false
 description: >-
   Audit a JavaScript/TypeScript repo's npm, yarn, or pnpm configuration for
   supply-chain hardening: tool version, lifecycle scripts, unsafe dependency

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -72,7 +72,7 @@ grep -E 'blockExoticSubdeps:' pnpm-workspace.yaml 2>/dev/null
 Scan all workspace `package.json` files (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`):
 
 ```bash
-find . -name package.json -not -path '*/node_modules/*' | head -50
+find . -name package.json -not -path '*/node_modules/*'
 ```
 
 **Safe values only:** semver range, `workspace:`, `patch:`, `npm:` alias to semver. Flag everything else (git URLs, tarballs, `user/repo` shorthand, `file:`, `link:`, `exec:`, …) as `path → name → value (protocol)`.

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -21,7 +21,7 @@ Read-only audit of the workspace root. Do not modify any files.
 ```bash
 test -f package.json || { echo "STOP: no package.json at workspace root"; exit 1; }
 jq -r '.packageManager // "unset"' package.json
-ls -1 yarn.lock package-lock.json pnpm-lock.yaml 2>/dev/null
+ls -1 yarn.lock package-lock.json pnpm-lock.yaml 2>/dev/null || true
 ```
 
 If no `package.json`, stop. Priority: `packageManager` → lockfile → default npm.

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -54,7 +54,7 @@ grep -E 'strictDepBuilds:|dangerouslyAllowAllBuilds:|allowBuilds:' pnpm-workspac
 |---------|------|------|
 | npm | `.npmrc` has `ignore-scripts=true` | missing or `false` |
 | yarn | `enableScripts: false` or key absent | `enableScripts: true` |
-| pnpm ≥ 11 | `strictDepBuilds` unset/`true`, `dangerouslyAllowAllBuilds` unset/`false` | `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true` |
+| pnpm ≥ 11 | `strictDepBuilds` unset/`true`, `dangerouslyAllowAllBuilds` unset/`false`, and `allowBuilds` unset/`[]` | `strictDepBuilds: false`, `dangerouslyAllowAllBuilds: true`, or `allowBuilds` non-empty |
 | pnpm 10 | `.npmrc` `ignore-scripts=true` OR `strictDepBuilds: true` | neither |
 
 pnpm 11+ ignores script settings in `.npmrc` and `package.json#pnpm`. pnpm 10 / yarn edge cases: [references/managers.md](references/managers.md).

--- a/skills/grafana-plugins/check-npm/SKILL.md
+++ b/skills/grafana-plugins/check-npm/SKILL.md
@@ -69,11 +69,9 @@ grep -E 'approvedGitRepositories:' .yarnrc.yml 2>/dev/null
 grep -E 'blockExoticSubdeps:' pnpm-workspace.yaml 2>/dev/null
 ```
 
-Scan all workspace `package.json` files (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`):
+Scan workspace `package.json` files (`dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`). Prefer workspace-member discovery (pnpm-workspace.yaml / root workspaces / lerna / rush) per [references/protocols.md](references/protocols.md), then scan only those manifests. Fallback (may overmatch non-workspace manifests):
 
-```bash
-find . -name package.json -not -path '*/node_modules/*'
-```
+    find . -name package.json -not -path '*/node_modules/*'
 
 **Safe values only:** semver range, `workspace:`, `patch:`, `npm:` alias to semver. Flag everything else (git URLs, tarballs, `user/repo` shorthand, `file:`, `link:`, `exec:`, …) as `path → name → value (protocol)`.
 

--- a/skills/grafana-plugins/check-npm/references/fix-snippets.md
+++ b/skills/grafana-plugins/check-npm/references/fix-snippets.md
@@ -1,0 +1,89 @@
+# Fix snippets (one per FAIL)
+
+## Tool version
+
+```bash
+npm install -g npm@11.15.0
+```
+
+```bash
+yarn set version stable
+```
+
+```bash
+npm install -g pnpm@11
+```
+
+## Lifecycle scripts
+
+`.npmrc`:
+
+```
+ignore-scripts=true
+```
+
+`pnpm-workspace.yaml` (pnpm 11 — do not use `.npmrc` for this):
+
+```yaml
+strictDepBuilds: true
+dangerouslyAllowAllBuilds: false
+```
+
+```bash
+yarn config set enableScripts false
+```
+
+## Unsafe dependency protocols
+
+`.npmrc`:
+
+```
+allow-git=none
+```
+
+`.yarnrc.yml` (block all git deps):
+
+```yaml
+approvedGitRepositories: []
+```
+
+`.yarnrc.yml` (Grafana internal repos):
+
+```yaml
+approvedGitRepositories:
+  - "https://github.com/grafana/*"
+  - "ssh://git@github.com/grafana/*"
+  - "git@github.com:grafana/*"
+```
+
+`pnpm-workspace.yaml`:
+
+```yaml
+blockExoticSubdeps: true
+```
+
+## Minimum release age
+
+`.npmrc` (days):
+
+```
+min-release-age=3
+```
+
+`.yarnrc.yml`:
+
+```yaml
+npmMinimalAgeGate: 4320  # or "3d"
+```
+
+`pnpm-workspace.yaml` (minutes):
+
+```yaml
+minimumReleaseAge: 4320
+```
+
+`.npmrc` (pnpm 10, minutes):
+
+```
+minimum-release-age=4320
+```

--- a/skills/grafana-plugins/check-npm/references/fix-snippets.md
+++ b/skills/grafana-plugins/check-npm/references/fix-snippets.md
@@ -11,7 +11,7 @@ yarn set version stable
 ```
 
 ```bash
-npm install -g pnpm@11
+npm install -g pnpm@11.0.0
 ```
 
 ## Lifecycle scripts

--- a/skills/grafana-plugins/check-npm/references/fix-snippets.md
+++ b/skills/grafana-plugins/check-npm/references/fix-snippets.md
@@ -7,7 +7,7 @@ npm install -g npm@11.15.0
 ```
 
 ```bash
-yarn set version stable
+yarn set version 4.14.0
 ```
 
 ```bash

--- a/skills/grafana-plugins/check-npm/references/fix-snippets.md
+++ b/skills/grafana-plugins/check-npm/references/fix-snippets.md
@@ -27,6 +27,7 @@ ignore-scripts=true
 ```yaml
 strictDepBuilds: true
 dangerouslyAllowAllBuilds: false
+allowBuilds: []
 ```
 
 ```bash

--- a/skills/grafana-plugins/check-npm/references/managers.md
+++ b/skills/grafana-plugins/check-npm/references/managers.md
@@ -1,0 +1,56 @@
+# Per-manager pass/fail criteria
+
+## Tool version thresholds
+
+| Manager | Command | Minimum | Notes |
+|---------|---------|---------|-------|
+| npm | `npm --version` | 11.15.0 | `allow-git` in 11.15; `min-release-age` in 11.10 |
+| yarn | `yarn --version` | 4.14.0 | `approvedGitRepositories` in 4.14 |
+| pnpm | `pnpm --version` | 11.0.0 | pnpm 11 defaults `minimumReleaseAge`, `strictDepBuilds`, `blockExoticSubdeps` on |
+
+If `packageManager` is pinned in root `package.json`, verify the pin meets the threshold. Use semver comparison.
+
+## Lifecycle scripts
+
+| Manager | Read | PASS | FAIL |
+|---------|------|------|------|
+| yarn | `.yarnrc.yml` | `enableScripts: false`, or key absent (yarn 4 default `false`) | `enableScripts: true` |
+| npm | `.npmrc` | `ignore-scripts=true` | missing or `ignore-scripts=false` |
+| pnpm ≥ 11 | `pnpm-workspace.yaml` | `strictDepBuilds` unset/`true` AND `dangerouslyAllowAllBuilds` unset/`false` | `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true` |
+| pnpm 10.x | `.npmrc`, `pnpm-workspace.yaml`, `package.json#pnpm` | `.npmrc` has `ignore-scripts=true` OR `strictDepBuilds: true` | neither, or `ignore-scripts=false`, or `strictDepBuilds: false` |
+| pnpm < 10 | `.npmrc` | `ignore-scripts=true` | otherwise |
+
+pnpm 11+ ignores build-script settings in `package.json#pnpm` and non-auth `.npmrc` entries.
+
+Detail column: if `allowBuilds` (pnpm 11) or `onlyBuiltDependencies` (pnpm 10) lists packages, note which can still run scripts.
+
+## Unsafe dependency protocols
+
+| Manager | Read | PASS | FAIL |
+|---------|------|------|------|
+| npm | `.npmrc` | `allow-git=none` or `allow-git=root` | missing, `allow-git=all` |
+| yarn | `.yarnrc.yml` + `package.json` scan | Posture A: `approvedGitRepositories: []` or all entries scoped to `grafana` org (three URL forms). Posture B: key omitted with explicit "do not add" comment AND scan clean | Offending `approvedGitRepositories` entries, or missing key + no policy comment + scan finds unsafe deps |
+| pnpm ≥ 11 | `pnpm-workspace.yaml` | `blockExoticSubdeps` unset/`true` | `blockExoticSubdeps: false` |
+| pnpm 10.x | `pnpm-workspace.yaml`, `package.json#pnpm` | `blockExoticSubdeps: true` | unset (default `false`) or `false` |
+
+npm < 11.15.0: `allow-git` in `.npmrc` is not enforced — call out in detail.
+
+Grafana yarn allow-list URL forms (same repos, different patterns):
+
+- `https://github.com/grafana/*`
+- `ssh://git@github.com/grafana/*`
+- `git@github.com:grafana/*`
+
+## Minimum release age
+
+3 days = **4320 minutes**. npm uses **days** (integer); yarn and pnpm use **minutes** (integer).
+
+| Manager | Read | PASS | FAIL |
+|---------|------|------|------|
+| npm | `.npmrc` | `min-release-age` ≥ `3` | missing (default off) |
+| yarn | `.yarnrc.yml` | `npmMinimalAgeGate` ≥ 4320 min (accepts `4320`, `"3d"`, `"72h"`) | missing or below threshold (default `0`) |
+| pnpm ≥ 11 | `pnpm-workspace.yaml` | `minimumReleaseAge` ≥ `4320` | unset (default `1440`) or below; also flag `minimumReleaseAgeStrict: false` |
+| pnpm 10.x | `.npmrc`, `pnpm-workspace.yaml`, `package.json#pnpm` | `minimum-release-age` / `minimumReleaseAge` ≥ `4320` | otherwise (default `0`) |
+| pnpm < 10 | — | — | setting unavailable; recommend upgrade |
+
+Detail column: list `npmPreapprovedPackages` (yarn) or `allowBuilds` exemptions when set.

--- a/skills/grafana-plugins/check-npm/references/managers.md
+++ b/skills/grafana-plugins/check-npm/references/managers.md
@@ -16,7 +16,7 @@ If `packageManager` is pinned in root `package.json`, verify the pin meets the t
 |---------|------|------|------|
 | yarn | `.yarnrc.yml` | `enableScripts: false`, or key absent (yarn 4 default `false`) | `enableScripts: true` |
 | npm | `.npmrc` | `ignore-scripts=true` | missing or `ignore-scripts=false` |
-| pnpm ≥ 11 | `pnpm-workspace.yaml` | `strictDepBuilds` unset/`true` AND `dangerouslyAllowAllBuilds` unset/`false` | `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true` |
+| pnpm ≥ 11 | `pnpm-workspace.yaml` | `strictDepBuilds` unset/`true` AND `dangerouslyAllowAllBuilds` unset/`false` AND `allowBuilds` unset/`[]` | `strictDepBuilds: false` or `dangerouslyAllowAllBuilds: true` or `allowBuilds` non-empty |
 | pnpm 10.x | `.npmrc`, `pnpm-workspace.yaml`, `package.json#pnpm` | `.npmrc` has `ignore-scripts=true` OR `strictDepBuilds: true` | neither, or `ignore-scripts=false`, or `strictDepBuilds: false` |
 | pnpm < 10 | `.npmrc` | `ignore-scripts=true` | otherwise |
 

--- a/skills/grafana-plugins/check-npm/references/managers.md
+++ b/skills/grafana-plugins/check-npm/references/managers.md
@@ -22,7 +22,7 @@ If `packageManager` is pinned in root `package.json`, verify the pin meets the t
 
 pnpm 11+ ignores build-script settings in `package.json#pnpm` and non-auth `.npmrc` entries.
 
-Detail column: if `allowBuilds` (pnpm 11) or `onlyBuiltDependencies` (pnpm 10) lists packages, note which can still run scripts.
+Detail column: if `allowBuilds` (pnpm 11) or `onlyBuiltDependencies` (pnpm 10) lists packages, list them (these are explicit build-script exemptions and should be treated as a FAIL per the criteria above).
 
 ## Unsafe dependency protocols
 

--- a/skills/grafana-plugins/check-npm/references/protocols.md
+++ b/skills/grafana-plugins/check-npm/references/protocols.md
@@ -1,0 +1,32 @@
+# Dependency protocol allow-list
+
+## Safe protocols
+
+- Valid **semver range** (`^1.2.3`, `~1.0`, `1.x`, `*`, exact `1.2.3`)
+- `workspace:` (`workspace:^`, `workspace:*`)
+- `patch:` (`patch:left-pad@1.0.0#~/patches/left-pad.patch`)
+- `npm:` alias resolving to semver (`npm:lodash@^4`)
+
+Everything else is unsafe — including yarn bare GitHub shorthand `user/repo` or `user/repo#commit`.
+
+## Workspace scan
+
+Scan root `package.json` and every workspace member. Discover members from `pnpm-workspace.yaml`, npm/yarn `workspaces`, `lerna.json`, or `rush.json`.
+
+Sections: `dependencies`, `devDependencies`, `optionalDependencies`, `peerDependencies`.
+
+Flag format:
+
+```
+path/to/package.json → name → value (protocol)
+```
+
+## Detection order
+
+1. Explicit `<scheme>:` prefix (`git:`, `git+https:`, `github:`, `link:`, `file:`, `exec:`, `jsr:`, …)
+2. `git@…` SSH URLs
+3. `http://` / `https://` tarball URLs
+4. Bare `user/repo` or `user/repo#…` (yarn GitHub shorthand)
+5. Not matching 1–4 and not valid semver → `(unknown)`
+
+Full yarn protocol list: <https://yarnpkg.com/protocols>


### PR DESCRIPTION
Adds two skills for Grafana plugin dependency hygiene:

- check-npm — audit of npm/yarn/pnpm hardening (scripts, git deps, min release age)
- audit-and-reduce-dependencies — pnpm cleanup workflow; runs /check-npm first, then removes unused deps and reports triage