### PR TITLE
fix: path for the incorrect grafana-datasources skill namespace

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -29,7 +29,6 @@
         "./skills/grafana-core/dashboarding",
         "./skills/grafana-core/promql",
         "./skills/grafana-core/grafana-oss",
-        "./skills/grafana-core/datasource-provisioning",
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
@@ -160,6 +159,21 @@
         "./skills/grafana-k6/k6",
         "./skills/grafana-k6/k6-perf-test-website",
         "./skills/grafana-k6/k6-manage"
+      ]
+    },
+    {
+      "name": "grafana-datasources",
+      "source": "./",
+      "description": "Skills for working with grafana data source plugins",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": [
+        "grafana",
+        "plugins",
+        "data-sources"
+      ],
+      "skills": [
+        "./skills/grafana-datasources/datasource-provisioning"
       ]
     }
   ]

--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -164,7 +164,7 @@
     {
       "name": "grafana-datasources",
       "source": "./",
-      "description": "Skills for working with grafana data source plugins",
+      "description": "Skills for working with Grafana data source plugins",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -173,7 +173,7 @@
         "data-sources"
       ],
       "skills": [
-        "./skills/grafana-datasources/datasource-provisioning"
+        "./skills/grafana-datasources/datasources-provisioning"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,7 +29,6 @@
         "./skills/grafana-core/dashboarding",
         "./skills/grafana-core/promql",
         "./skills/grafana-core/grafana-oss",
-        "./skills/grafana-core/datasource-provisioning",
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
@@ -160,6 +159,21 @@
         "./skills/grafana-k6/k6",
         "./skills/grafana-k6/k6-perf-test-website",
         "./skills/grafana-k6/k6-manage"
+      ]
+    },
+    {
+      "name": "grafana-datasources",
+      "source": "./",
+      "description": "Skills for working with grafana data source plugins",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": [
+        "grafana",
+        "plugins",
+        "data-sources"
+      ],
+      "skills": [
+        "./skills/grafana-datasources/datasource-provisioning"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -164,7 +164,7 @@
     {
       "name": "grafana-datasources",
       "source": "./",
-      "description": "Skills for working with grafana data source plugins",
+      "description": "Skills for working with Grafana data source plugins",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -173,7 +173,7 @@
         "data-sources"
       ],
       "skills": [
-        "./skills/grafana-datasources/datasource-provisioning"
+        "./skills/grafana-datasources/datasources-provisioning"
       ]
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -29,7 +29,6 @@
         "./skills/grafana-core/dashboarding",
         "./skills/grafana-core/promql",
         "./skills/grafana-core/grafana-oss",
-        "./skills/grafana-core/datasource-provisioning",
         "./skills/grafana-core/alloy",
         "./skills/grafana-core/beyla",
         "./skills/grafana-core/opentelemetry",
@@ -160,6 +159,21 @@
         "./skills/grafana-k6/k6",
         "./skills/grafana-k6/k6-perf-test-website",
         "./skills/grafana-k6/k6-manage"
+      ]
+    },
+    {
+      "name": "grafana-datasources",
+      "source": "./",
+      "description": "Skills for working with grafana data source plugins",
+      "version": "0.1.0",
+      "category": "grafana",
+      "tags": [
+        "grafana",
+        "plugins",
+        "data-sources"
+      ],
+      "skills": [
+        "./skills/grafana-datasources/datasource-provisioning"
       ]
     }
   ]

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -164,7 +164,7 @@
     {
       "name": "grafana-datasources",
       "source": "./",
-      "description": "Skills for working with grafana data source plugins",
+      "description": "Skills for working with Grafana data source plugins",
       "version": "0.1.0",
       "category": "grafana",
       "tags": [

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -173,7 +173,7 @@
         "data-sources"
       ],
       "skills": [
-        "./skills/grafana-datasources/datasource-provisioning"
+        "./skills/grafana-datasources/datasources-provisioning"
       ]
     }
   ]

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Grafana Labs
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -146,11 +146,11 @@ Skills for working with k6 open-source load testing.
 
 ### grafana-datasources
 
-Skills for working with grafana data source plugins
+Skills for working with Grafana data source plugins.
 
 | Skill                                                                          | Description                                                                  |
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [datasources-provisioning](skills/grafana-datasources/datasources-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
+| [datasources-provisioning](skills/grafana-datasources/datasources-provisioning) | Authoring and schema discovery of Grafana data source plugin's configuration |
 
 ---
 
@@ -179,7 +179,7 @@ grafana-skills/
 │   ├── grafana-lgtm/
 │   ├── grafana-plugins/
 │   ├── grafana-app-sdk/
-│   └── grafana-k6/
+│   ├── grafana-k6/
 │   └── grafana-datasources/
 ├── template/SKILL.md                 # Starter template for new skills
 ├── scripts/lint-skills.sh            # Local skill validation

--- a/README.md
+++ b/README.md
@@ -65,84 +65,84 @@ Skills are organized into plugin groups. All skill files live under `skills/<plu
 
 Core Grafana concepts — dashboards, visualization, PromQL, alerting, and telemetry collection.
 
-| Skill                                              | Description                                                                                   |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| [grafana-oss](skills/grafana-core/grafana-oss)     | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration     |
-| [dashboarding](skills/grafana-core/dashboarding)   | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds   |
-| [promql](skills/grafana-core/promql)               | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics         |
-| [alerting-irm](skills/grafana-core/alerting-irm)   | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
-| [alloy](skills/grafana-core/alloy)                 | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines  |
-| [beyla](skills/grafana-core/beyla)                 | Grafana Beyla eBPF auto-instrumentation for zero-code application observability               |
-| [opentelemetry](skills/grafana-core/opentelemetry) | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors              |
+| Skill | Description |
+|-------|-------------|
+| [grafana-oss](skills/grafana-core/grafana-oss) | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration |
+| [dashboarding](skills/grafana-core/dashboarding) | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds |
+| [promql](skills/grafana-core/promql) | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics |
+| [alerting-irm](skills/grafana-core/alerting-irm) | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
+| [alloy](skills/grafana-core/alloy) | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines |
+| [beyla](skills/grafana-core/beyla) | Grafana Beyla eBPF auto-instrumentation for zero-code application observability |
+| [opentelemetry](skills/grafana-core/opentelemetry) | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors |
 
 ### grafana-cloud
 
 Grafana Cloud — fleet management, cloud integrations, cost optimization, and AI agent connectivity.
 
-| Skill                                                                                               | Description                                                                                     |
-| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [admin](skills/grafana-cloud/admin)                                                                 | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts       |
-| [send-data](skills/grafana-cloud/send-data)                                                         | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs         |
-| [fleet-management](skills/grafana-cloud/fleet-management)                                           | Manage Grafana Alloy collector fleets with remote configuration and OpAMP                       |
-| [cloud-integrations](skills/grafana-cloud/cloud-integrations)                                       | Connect AWS, Azure, and other cloud providers to Grafana Cloud                                  |
-| [infrastructure](skills/grafana-cloud/infrastructure)                                               | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations          |
-| [app-observability](skills/grafana-cloud/app-observability)                                         | Application Observability (APM), Frontend Observability (Faro), and AI Observability            |
-| [database-observability](skills/grafana-cloud/database-observability)                               | Query-level performance insights for MySQL and PostgreSQL                                       |
-| [adaptive-metrics](skills/grafana-cloud/adaptive-metrics)                                           | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management          |
-| [cost-management](skills/grafana-cloud/cost-management)                                             | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization                      |
-| [dpm-finder](skills/grafana-cloud/dpm-finder)                                                       | Identify Prometheus metrics driving high Data Points per Minute (DPM)                           |
-| [loki-label-analyzer](skills/grafana-cloud/loki-label-analyzer)                                     | Evaluate and improve Loki label strategy using cardinality, query patterns, and label hygiene   |
-| [prometheus-label-strategy](skills/grafana-cloud/prometheus-label-strategy)                         | Audit and design Prometheus label schemas — cardinality, histograms, source-side prevention     |
-| [prometheus-cardinality-troubleshooter](skills/grafana-cloud/prometheus-cardinality-troubleshooter) | Diagnose live Prometheus cardinality issues — slow queries, OOMs, high Active Series bills      |
-| [oncall-irm](skills/grafana-cloud/oncall-irm)                                                       | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle               |
-| [ml-ai](skills/grafana-cloud/ml-ai)                                                                 | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin     |
-| [assistant-mcp](skills/grafana-cloud/assistant-mcp)                                                 | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP                  |
-| [private-connectivity](skills/grafana-cloud/private-connectivity)                                   | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
-| [testing](skills/grafana-cloud/testing)                                                             | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability                         |
+| Skill | Description |
+|-------|-------------|
+| [admin](skills/grafana-cloud/admin) | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts |
+| [send-data](skills/grafana-cloud/send-data) | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs |
+| [fleet-management](skills/grafana-cloud/fleet-management) | Manage Grafana Alloy collector fleets with remote configuration and OpAMP |
+| [cloud-integrations](skills/grafana-cloud/cloud-integrations) | Connect AWS, Azure, and other cloud providers to Grafana Cloud |
+| [infrastructure](skills/grafana-cloud/infrastructure) | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations |
+| [app-observability](skills/grafana-cloud/app-observability) | Application Observability (APM), Frontend Observability (Faro), and AI Observability |
+| [database-observability](skills/grafana-cloud/database-observability) | Query-level performance insights for MySQL and PostgreSQL |
+| [adaptive-metrics](skills/grafana-cloud/adaptive-metrics) | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management |
+| [cost-management](skills/grafana-cloud/cost-management) | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization |
+| [dpm-finder](skills/grafana-cloud/dpm-finder) | Identify Prometheus metrics driving high Data Points per Minute (DPM) |
+| [loki-label-analyzer](skills/grafana-cloud/loki-label-analyzer) | Evaluate and improve Loki label strategy using cardinality, query patterns, and label hygiene |
+| [prometheus-label-strategy](skills/grafana-cloud/prometheus-label-strategy) | Audit and design Prometheus label schemas — cardinality, histograms, source-side prevention |
+| [prometheus-cardinality-troubleshooter](skills/grafana-cloud/prometheus-cardinality-troubleshooter) | Diagnose live Prometheus cardinality issues — slow queries, OOMs, high Active Series bills |
+| [oncall-irm](skills/grafana-cloud/oncall-irm) | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle |
+| [ml-ai](skills/grafana-cloud/ml-ai) | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin |
+| [assistant-mcp](skills/grafana-cloud/assistant-mcp) | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |
+| [private-connectivity](skills/grafana-cloud/private-connectivity) | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
+| [testing](skills/grafana-cloud/testing) | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability |
 
 ### grafana-lgtm
 
 Open-source LGTM observability stack — Loki, Tempo, Prometheus/Mimir, and Pyroscope.
 
-| Skill                                        | Description                                                                                  |
-| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| [loki](skills/grafana-lgtm/loki)             | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture               |
-| [tempo](skills/grafana-lgtm/tempo)           | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations           |
-| [prometheus](skills/grafana-lgtm/prometheus) | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir                       |
-| [mimir](skills/grafana-lgtm/mimir)           | Scalable long-term metrics storage with Grafana Mimir — architecture and operations          |
-| [pyroscope](skills/grafana-lgtm/pyroscope)   | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
+| Skill | Description |
+|-------|-------------|
+| [loki](skills/grafana-lgtm/loki) | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture |
+| [tempo](skills/grafana-lgtm/tempo) | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations |
+| [prometheus](skills/grafana-lgtm/prometheus) | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir |
+| [mimir](skills/grafana-lgtm/mimir) | Scalable long-term metrics storage with Grafana Mimir — architecture and operations |
+| [pyroscope](skills/grafana-lgtm/pyroscope) | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
 
 ### grafana-plugins
 
 Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework.
 
-| Skill                                                                         | Description                                                                                    |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size)               | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
-| [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13                         |
-| [grafana-scenes](skills/grafana-plugins/grafana-scenes)                       | Build Grafana plugin pages using the @grafana/scenes framework                                 |
+| Skill | Description |
+|-------|-------------|
+| [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size) | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
+| [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13 |
+| [grafana-scenes](skills/grafana-plugins/grafana-scenes) | Build Grafana plugin pages using the @grafana/scenes framework |
 
 ### grafana-app-sdk
 
 Skills for building apps on the Grafana App Platform using grafana-app-sdk.
 
-| Skill                                                             | Description                                                                                     |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| [app-sdk-concepts](skills/grafana-app-sdk/app-sdk-concepts)       | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
-| [cue-kind-definition](skills/grafana-app-sdk/cue-kind-definition) | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config               |
-| [reconciler-logic](skills/grafana-app-sdk/reconciler-logic)       | Implement async reconciler and watcher business logic                                           |
-| [admission-control](skills/grafana-app-sdk/admission-control)     | Write validation and mutation admission handlers                                                |
+| Skill | Description |
+|-------|-------------|
+| [app-sdk-concepts](skills/grafana-app-sdk/app-sdk-concepts) | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
+| [cue-kind-definition](skills/grafana-app-sdk/cue-kind-definition) | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config |
+| [reconciler-logic](skills/grafana-app-sdk/reconciler-logic) | Implement async reconciler and watcher business logic |
+| [admission-control](skills/grafana-app-sdk/admission-control) | Write validation and mutation admission handlers |
 
 ### grafana-k6
 
 Skills for working with k6 open-source load testing.
 
-| Skill                                                          | Description                                                                                                                                                                                             |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [k6](skills/grafana-k6/k6)                                     | k6 performance and load testing — test scripts, executors, thresholds, scenarios, and k6 Cloud execution                                                                                                |
-| [k6-docs](skills/grafana-k6/k6-docs)                           | Write or review k6 documentation across TypeScript types, user docs, and release notes                                                                                                                  |
+| Skill | Description |
+|-------|-------------|
+| [k6](skills/grafana-k6/k6) | k6 performance and load testing — test scripts, executors, thresholds, scenarios, and k6 Cloud execution |
+| [k6-docs](skills/grafana-k6/k6-docs) | Write or review k6 documentation across TypeScript types, user docs, and release notes |
 | [k6-perf-test-website](skills/grafana-k6/k6-perf-test-website) | Performance-test a public website end-to-end with k6. Produces a hybrid protocol+browser test suite, SLO-backed thresholds, a load-generator monitor sidecar, and a Grafana-side investigation playbook |
-| [k6-manage](skills/grafana-k6/k6-manage)                       | Operate Grafana Cloud k6 (GCk6) via the `gcx` CLI or direct curl — manage tests, runs, scripts, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights                   |
+| [k6-manage](skills/grafana-k6/k6-manage) | Operate Grafana Cloud k6 (GCk6) via the `gcx` CLI or direct curl — manage tests, runs, scripts, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights |
 
 ### grafana-datasources
 
@@ -150,7 +150,7 @@ Skills for working with grafana data source plugins
 
 | Skill                                                                          | Description                                                                  |
 | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [datasource-provisioning](skills/grafana-datasources/datasources-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
+| [datasources-provisioning](skills/grafana-datasources/datasources-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
 
 ---
 
@@ -180,6 +180,7 @@ grafana-skills/
 │   ├── grafana-plugins/
 │   ├── grafana-app-sdk/
 │   └── grafana-k6/
+│   └── grafana-datasources/
 ├── template/SKILL.md                 # Starter template for new skills
 ├── scripts/lint-skills.sh            # Local skill validation
 └── .github/workflows/                # CI validation

--- a/README.md
+++ b/README.md
@@ -65,92 +65,92 @@ Skills are organized into plugin groups. All skill files live under `skills/<plu
 
 Core Grafana concepts — dashboards, visualization, PromQL, alerting, and telemetry collection.
 
-| Skill | Description |
-|-------|-------------|
-| [grafana-oss](skills/grafana-core/grafana-oss) | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration |
-| [dashboarding](skills/grafana-core/dashboarding) | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds |
-| [promql](skills/grafana-core/promql) | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics |
-| [alerting-irm](skills/grafana-core/alerting-irm) | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
-| [alloy](skills/grafana-core/alloy) | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines |
-| [beyla](skills/grafana-core/beyla) | Grafana Beyla eBPF auto-instrumentation for zero-code application observability |
-| [opentelemetry](skills/grafana-core/opentelemetry) | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors |
+| Skill                                              | Description                                                                                   |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| [grafana-oss](skills/grafana-core/grafana-oss)     | Grafana OSS core — dashboards, data sources, provisioning, RBAC, and server configuration     |
+| [dashboarding](skills/grafana-core/dashboarding)   | Create and organise Grafana dashboards — panels, variables, transformations, and thresholds   |
+| [promql](skills/grafana-core/promql)               | Write, validate, and optimise PromQL queries for Prometheus and Grafana Cloud Metrics         |
+| [alerting-irm](skills/grafana-core/alerting-irm)   | Grafana Alerting, Incident Response Management, and SLOs — rules, contact points, and on-call |
+| [alloy](skills/grafana-core/alloy)                 | Grafana Alloy OpenTelemetry collector — config language, components, and telemetry pipelines  |
+| [beyla](skills/grafana-core/beyla)                 | Grafana Beyla eBPF auto-instrumentation for zero-code application observability               |
+| [opentelemetry](skills/grafana-core/opentelemetry) | OpenTelemetry with the Grafana stack — SDK instrumentation, OTLP, and collectors              |
 
 ### grafana-cloud
 
 Grafana Cloud — fleet management, cloud integrations, cost optimization, and AI agent connectivity.
 
-| Skill | Description |
-|-------|-------------|
-| [admin](skills/grafana-cloud/admin) | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts |
-| [send-data](skills/grafana-cloud/send-data) | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs |
-| [fleet-management](skills/grafana-cloud/fleet-management) | Manage Grafana Alloy collector fleets with remote configuration and OpAMP |
-| [cloud-integrations](skills/grafana-cloud/cloud-integrations) | Connect AWS, Azure, and other cloud providers to Grafana Cloud |
-| [infrastructure](skills/grafana-cloud/infrastructure) | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations |
-| [app-observability](skills/grafana-cloud/app-observability) | Application Observability (APM), Frontend Observability (Faro), and AI Observability |
-| [database-observability](skills/grafana-cloud/database-observability) | Query-level performance insights for MySQL and PostgreSQL |
-| [adaptive-metrics](skills/grafana-cloud/adaptive-metrics) | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management |
-| [cost-management](skills/grafana-cloud/cost-management) | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization |
-| [dpm-finder](skills/grafana-cloud/dpm-finder) | Identify Prometheus metrics driving high Data Points per Minute (DPM) |
-| [loki-label-analyzer](skills/grafana-cloud/loki-label-analyzer) | Evaluate and improve Loki label strategy using cardinality, query patterns, and label hygiene |
-| [prometheus-label-strategy](skills/grafana-cloud/prometheus-label-strategy) | Audit and design Prometheus label schemas — cardinality, histograms, source-side prevention |
-| [prometheus-cardinality-troubleshooter](skills/grafana-cloud/prometheus-cardinality-troubleshooter) | Diagnose live Prometheus cardinality issues — slow queries, OOMs, high Active Series bills |
-| [oncall-irm](skills/grafana-cloud/oncall-irm) | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle |
-| [ml-ai](skills/grafana-cloud/ml-ai) | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin |
-| [assistant-mcp](skills/grafana-cloud/assistant-mcp) | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |
-| [private-connectivity](skills/grafana-cloud/private-connectivity) | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
-| [testing](skills/grafana-cloud/testing) | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability |
+| Skill                                                                                               | Description                                                                                     |
+| --------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [admin](skills/grafana-cloud/admin)                                                                 | Grafana Cloud account management — organizations, stacks, RBAC, SSO, and service accounts       |
+| [send-data](skills/grafana-cloud/send-data)                                                         | Send telemetry to Grafana Cloud — metrics, logs, traces, and profiles via Alloy or SDKs         |
+| [fleet-management](skills/grafana-cloud/fleet-management)                                           | Manage Grafana Alloy collector fleets with remote configuration and OpAMP                       |
+| [cloud-integrations](skills/grafana-cloud/cloud-integrations)                                       | Connect AWS, Azure, and other cloud providers to Grafana Cloud                                  |
+| [infrastructure](skills/grafana-cloud/infrastructure)                                               | Infrastructure monitoring — Kubernetes, host/container metrics, and cloud integrations          |
+| [app-observability](skills/grafana-cloud/app-observability)                                         | Application Observability (APM), Frontend Observability (Faro), and AI Observability            |
+| [database-observability](skills/grafana-cloud/database-observability)                               | Query-level performance insights for MySQL and PostgreSQL                                       |
+| [adaptive-metrics](skills/grafana-cloud/adaptive-metrics)                                           | Reduce metrics cost with Adaptive Metrics aggregation rules and cardinality management          |
+| [cost-management](skills/grafana-cloud/cost-management)                                             | Grafana Cloud cost monitoring, attribution, usage alerts, and optimization                      |
+| [dpm-finder](skills/grafana-cloud/dpm-finder)                                                       | Identify Prometheus metrics driving high Data Points per Minute (DPM)                           |
+| [loki-label-analyzer](skills/grafana-cloud/loki-label-analyzer)                                     | Evaluate and improve Loki label strategy using cardinality, query patterns, and label hygiene   |
+| [prometheus-label-strategy](skills/grafana-cloud/prometheus-label-strategy)                         | Audit and design Prometheus label schemas — cardinality, histograms, source-side prevention     |
+| [prometheus-cardinality-troubleshooter](skills/grafana-cloud/prometheus-cardinality-troubleshooter) | Diagnose live Prometheus cardinality issues — slow queries, OOMs, high Active Series bills      |
+| [oncall-irm](skills/grafana-cloud/oncall-irm)                                                       | Grafana OnCall and IRM — alert routing, escalation chains, and incident lifecycle               |
+| [ml-ai](skills/grafana-cloud/ml-ai)                                                                 | AI/ML features — Grafana Assistant, Dynamic Alerting, Sift, Knowledge Graph, and LLM Plugin     |
+| [assistant-mcp](skills/grafana-cloud/assistant-mcp)                                                 | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP                  |
+| [private-connectivity](skills/grafana-cloud/private-connectivity)                                   | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
+| [testing](skills/grafana-cloud/testing)                                                             | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability                         |
 
 ### grafana-lgtm
 
 Open-source LGTM observability stack — Loki, Tempo, Prometheus/Mimir, and Pyroscope.
 
-| Skill | Description |
-|-------|-------------|
-| [loki](skills/grafana-lgtm/loki) | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture |
-| [tempo](skills/grafana-lgtm/tempo) | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations |
-| [prometheus](skills/grafana-lgtm/prometheus) | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir |
-| [mimir](skills/grafana-lgtm/mimir) | Scalable long-term metrics storage with Grafana Mimir — architecture and operations |
-| [pyroscope](skills/grafana-lgtm/pyroscope) | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
+| Skill                                        | Description                                                                                  |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [loki](skills/grafana-lgtm/loki)             | Log aggregation with Grafana Loki — LogQL queries, pipelines, and architecture               |
+| [tempo](skills/grafana-lgtm/tempo)           | Distributed tracing with Grafana Tempo — TraceQL, service graphs, and correlations           |
+| [prometheus](skills/grafana-lgtm/prometheus) | Metrics with Prometheus — PromQL, alerting, recording rules, and Mimir                       |
+| [mimir](skills/grafana-lgtm/mimir)           | Scalable long-term metrics storage with Grafana Mimir — architecture and operations          |
+| [pyroscope](skills/grafana-lgtm/pyroscope)   | Continuous profiling with Grafana Pyroscope — flame graphs, diff views, and language support |
 
 ### grafana-plugins
 
 Skills for building Grafana plugins — bundle optimisation, code splitting, React 19 migration, and the @grafana/scenes framework.
 
-| Skill | Description |
-|-------|-------------|
-| [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size) | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
-| [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13 |
-| [grafana-scenes](skills/grafana-plugins/grafana-scenes) | Build Grafana plugin pages using the @grafana/scenes framework |
+| Skill                                                                         | Description                                                                                    |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [plugin-bundle-size](skills/grafana-plugins/plugin-bundle-size)               | Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting |
+| [react-19-plugin-migration](skills/grafana-plugins/react-19-plugin-migration) | Migrate a Grafana plugin to React 19 compatibility ahead of Grafana 13                         |
+| [grafana-scenes](skills/grafana-plugins/grafana-scenes)                       | Build Grafana plugin pages using the @grafana/scenes framework                                 |
 
 ### grafana-app-sdk
 
 Skills for building apps on the Grafana App Platform using grafana-app-sdk.
 
-| Skill | Description |
-|-------|-------------|
-| [app-sdk-concepts](skills/grafana-app-sdk/app-sdk-concepts) | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
-| [cue-kind-definition](skills/grafana-app-sdk/cue-kind-definition) | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config |
-| [reconciler-logic](skills/grafana-app-sdk/reconciler-logic) | Implement async reconciler and watcher business logic |
-| [admission-control](skills/grafana-app-sdk/admission-control) | Write validation and mutation admission handlers |
+| Skill                                                             | Description                                                                                     |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| [app-sdk-concepts](skills/grafana-app-sdk/app-sdk-concepts)       | Project init, deployment modes (standalone operator, grafana/apps, frontend-only), and workflow |
+| [cue-kind-definition](skills/grafana-app-sdk/cue-kind-definition) | Author CUE kind definitions — schemas, versioning, spec vs status, codegen config               |
+| [reconciler-logic](skills/grafana-app-sdk/reconciler-logic)       | Implement async reconciler and watcher business logic                                           |
+| [admission-control](skills/grafana-app-sdk/admission-control)     | Write validation and mutation admission handlers                                                |
 
 ### grafana-k6
 
 Skills for working with k6 open-source load testing.
 
-| Skill | Description |
-|-------|-------------|
-| [k6](skills/grafana-k6/k6) | k6 performance and load testing — test scripts, executors, thresholds, scenarios, and k6 Cloud execution |
-| [k6-docs](skills/grafana-k6/k6-docs) | Write or review k6 documentation across TypeScript types, user docs, and release notes |
+| Skill                                                          | Description                                                                                                                                                                                             |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [k6](skills/grafana-k6/k6)                                     | k6 performance and load testing — test scripts, executors, thresholds, scenarios, and k6 Cloud execution                                                                                                |
+| [k6-docs](skills/grafana-k6/k6-docs)                           | Write or review k6 documentation across TypeScript types, user docs, and release notes                                                                                                                  |
 | [k6-perf-test-website](skills/grafana-k6/k6-perf-test-website) | Performance-test a public website end-to-end with k6. Produces a hybrid protocol+browser test suite, SLO-backed thresholds, a load-generator monitor sidecar, and a Grafana-side investigation playbook |
-| [k6-manage](skills/grafana-k6/k6-manage) | Operate Grafana Cloud k6 (GCk6) via the `gcx` CLI or direct curl — manage tests, runs, scripts, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights |
+| [k6-manage](skills/grafana-k6/k6-manage)                       | Operate Grafana Cloud k6 (GCk6) via the `gcx` CLI or direct curl — manage tests, runs, scripts, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights                   |
 
 ### grafana-datasources
 
 Skills for working with grafana data source plugins
 
-| Skill                                                                         | Description                                                                  |
-| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [datasource-provisioning](skills/grafana-datasources/datasource-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
+| Skill                                                                          | Description                                                                  |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| [datasource-provisioning](skills/grafana-datasources/datasources-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ claude plugin install grafana-cloud@grafana-skills
 claude plugin install grafana-lgtm@grafana-skills
 claude plugin install grafana-app-sdk@grafana-skills
 claude plugin install grafana-k6@grafana-skills
+claude plugin install grafana-datasources@grafana-skills
 ```
 
 ### Cursor
@@ -142,6 +143,14 @@ Skills for working with k6 open-source load testing.
 | [k6-docs](skills/grafana-k6/k6-docs) | Write or review k6 documentation across TypeScript types, user docs, and release notes |
 | [k6-perf-test-website](skills/grafana-k6/k6-perf-test-website) | Performance-test a public website end-to-end with k6. Produces a hybrid protocol+browser test suite, SLO-backed thresholds, a load-generator monitor sidecar, and a Grafana-side investigation playbook |
 | [k6-manage](skills/grafana-k6/k6-manage) | Operate Grafana Cloud k6 (GCk6) via the `gcx` CLI or direct curl — manage tests, runs, scripts, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights |
+
+### grafana-datasources
+
+Skills for working with grafana data source plugins
+
+| Skill                                                                         | Description                                                                  |
+| ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| [datasource-provisioning](skills/grafana-datasources/datasource-provisioning) | Authoring and schema discovery of grafana data source plugin's configuration |
 
 ---
 

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -133,6 +133,18 @@
           "tags": ["k6", "load-testing", "grafana-cloud", "gcx", "test-runs", "metrics", "logs"]
         }
       ]
+    },
+    {
+      "name": "grafana-datasources",
+      "description": "Skills for working with grafana data source plugins",
+      "skills": [
+        {
+          "name": "datasources-provisioning",
+          "description": "Authoring and schema discovery of grafana data source plugin's configuration",
+          "path": "skills/grafana-datasources/datasource-provisioning",
+          "tags": ["grafana", "plugins", "data-sources"]
+        }
+      ]
     }
   ]
 }

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -243,11 +243,11 @@
     },
     {
       "name": "grafana-datasources",
-      "description": "Skills for working with grafana data source plugins",
+      "description": "Skills for working with Grafana data source plugins",
       "skills": [
         {
           "name": "datasources-provisioning",
-          "description": "Authoring and schema discovery of grafana data source plugin's configuration",
+          "description": "Authoring and schema discovery of Grafana data source plugin's configuration",
           "path": "skills/grafana-datasources/datasources-provisioning",
           "tags": [
             "grafana",

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -11,19 +11,37 @@
           "name": "plugin-bundle-size",
           "description": "Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting. Use when the user asks to reduce plugin bundle size, fix large bundles, or split plugin code.",
           "path": "skills/grafana-plugins/plugin-bundle-size",
-          "tags": ["plugins", "bundle-size", "webpack", "react", "performance"]
+          "tags": [
+            "plugins",
+            "bundle-size",
+            "webpack",
+            "react",
+            "performance"
+          ]
         },
         {
           "name": "react-19-plugin-migration",
           "description": "Migrate a Grafana plugin to React 19 compatibility. Use when the user asks to update a plugin for React 19, fix React 19 build errors, or prepare a plugin for Grafana 12.",
           "path": "skills/grafana-plugins/react-19-plugin-migration",
-          "tags": ["plugins", "react", "migration", "react-19"]
+          "tags": [
+            "plugins",
+            "react",
+            "migration",
+            "react-19"
+          ]
         },
         {
           "name": "grafana-scenes",
           "description": "Build Grafana plugin pages using the @grafana/scenes framework. Use when creating scene pages, adding panels, setting up drilldown navigation, defining variables, or working with SceneApp, EmbeddedScene, SceneQueryRunner, or PanelBuilders.",
           "path": "skills/grafana-plugins/grafana-scenes",
-          "tags": ["plugins", "scenes", "react", "grafana-scenes", "drilldown", "panels"]
+          "tags": [
+            "plugins",
+            "scenes",
+            "react",
+            "grafana-scenes",
+            "drilldown",
+            "panels"
+          ]
         }
       ]
     },
@@ -40,13 +58,27 @@
           "name": "dpm-finder",
           "description": "Grafana Professional Services tool for identifying which Prometheus metrics drive high Data Points per Minute (DPM). Analyzes metric-level DPM with per-label breakdown to help optimize Grafana Cloud costs. Use when the user asks about DPM analysis, high-cardinality metrics, metric cost optimization, finding noisy metrics, or running dpm-finder.",
           "path": "skills/grafana-cloud/dpm-finder",
-          "tags": ["grafana-cloud", "dpm", "metrics", "cost-optimization", "prometheus", "professional-services"]
+          "tags": [
+            "grafana-cloud",
+            "dpm",
+            "metrics",
+            "cost-optimization",
+            "prometheus",
+            "professional-services"
+          ]
         },
         {
           "name": "loki-label-analyzer",
           "description": "Expert evaluator for Grafana Loki label strategy. Audits, designs, and improves label schemas using cardinality scoring, access-pattern alignment, static vs. dynamic label rules, and consistency checks. Use when the user asks to evaluate, audit, design, or improve a Loki label strategy — or asks why their Loki queries are slow.",
           "path": "skills/grafana-cloud/loki-label-analyzer",
-          "tags": ["grafana-cloud", "loki", "logs", "labels", "cardinality", "alloy"]
+          "tags": [
+            "grafana-cloud",
+            "loki",
+            "logs",
+            "labels",
+            "cardinality",
+            "alloy"
+          ]
         }
       ]
     },
@@ -58,25 +90,51 @@
           "name": "loki",
           "description": "Grafana Loki log aggregation including LogQL queries, log pipelines, structured metadata, and integration patterns. Use when working with Loki, writing LogQL queries, configuring log pipelines, or discussing log aggregation architecture.",
           "path": "skills/grafana-lgtm/loki",
-          "tags": ["loki", "logs", "logql", "log-aggregation", "logging"]
+          "tags": [
+            "loki",
+            "logs",
+            "logql",
+            "log-aggregation",
+            "logging"
+          ]
         },
         {
           "name": "tempo",
           "description": "Grafana Tempo distributed tracing including TraceQL queries, service graphs, trace correlations, and OpenTelemetry integration. Use when working with Tempo, writing TraceQL queries, configuring trace-to-logs/metrics/profiles, or discussing distributed tracing.",
           "path": "skills/grafana-lgtm/tempo",
-          "tags": ["tempo", "tracing", "traceql", "opentelemetry", "distributed-tracing", "service-graph"]
+          "tags": [
+            "tempo",
+            "tracing",
+            "traceql",
+            "opentelemetry",
+            "distributed-tracing",
+            "service-graph"
+          ]
         },
         {
           "name": "prometheus",
           "description": "Prometheus and Grafana Cloud Metrics including PromQL queries, alerting, recording rules, and integration patterns. Use when working with Prometheus, writing PromQL queries beyond basic usage, configuring Alertmanager, or discussing metrics architecture.",
           "path": "skills/grafana-lgtm/prometheus",
-          "tags": ["prometheus", "mimir", "metrics", "promql", "alerting", "recording-rules"]
+          "tags": [
+            "prometheus",
+            "mimir",
+            "metrics",
+            "promql",
+            "alerting",
+            "recording-rules"
+          ]
         },
         {
           "name": "pyroscope",
           "description": "Grafana Pyroscope continuous profiling including profile types, flame graphs, diff views, and language support. Use when working with Pyroscope, analyzing flame graphs, optimizing code performance, or integrating profiling with traces.",
           "path": "skills/grafana-lgtm/pyroscope",
-          "tags": ["pyroscope", "profiling", "flame-graphs", "performance", "continuous-profiling"]
+          "tags": [
+            "pyroscope",
+            "profiling",
+            "flame-graphs",
+            "performance",
+            "continuous-profiling"
+          ]
         }
       ]
     },
@@ -88,25 +146,53 @@
           "name": "app-sdk-concepts",
           "description": "Grafana App SDK foundational concepts including project initialization, deployment modes (standalone operator, grafana/apps, frontend-only), and the overall development workflow. Use when creating a Grafana app, initializing a grafana-app-sdk project, or asking about deployment modes.",
           "path": "skills/grafana-app-sdk/app-sdk-concepts",
-          "tags": ["app-sdk", "app-platform", "grafana", "kubernetes", "operator", "cue"]
+          "tags": [
+            "app-sdk",
+            "app-platform",
+            "grafana",
+            "kubernetes",
+            "operator",
+            "cue"
+          ]
         },
         {
           "name": "cue-kind-definition",
           "description": "CUE kind definitions and schemas for grafana-app-sdk projects. Use when defining a kind, adding a CUE kind, writing a kind schema, modeling a resource, adding versions, or asking about CUE kind structure, codegen config, spec vs status, or versioning.",
           "path": "skills/grafana-app-sdk/cue-kind-definition",
-          "tags": ["app-sdk", "cue", "kinds", "schema", "codegen", "app-platform"]
+          "tags": [
+            "app-sdk",
+            "cue",
+            "kinds",
+            "schema",
+            "codegen",
+            "app-platform"
+          ]
         },
         {
           "name": "reconciler-logic",
           "description": "Reconciler and watcher business logic for grafana-app-sdk apps. Use when writing a reconciler, implementing async resource processing, handling create/update/delete events, using TypedReconciler, or writing a controller.",
           "path": "skills/grafana-app-sdk/reconciler-logic",
-          "tags": ["app-sdk", "reconciler", "watcher", "kubernetes", "controller", "operator"]
+          "tags": [
+            "app-sdk",
+            "reconciler",
+            "watcher",
+            "kubernetes",
+            "controller",
+            "operator"
+          ]
         },
         {
           "name": "admission-control",
           "description": "Validation and mutation admission handlers for grafana-app-sdk apps. Use when writing a validator, adding admission control, implementing a mutating webhook, validating incoming resources, or asking how to validate or mutate resources before persistence.",
           "path": "skills/grafana-app-sdk/admission-control",
-          "tags": ["app-sdk", "admission", "validation", "mutation", "webhook", "kubernetes"]
+          "tags": [
+            "app-sdk",
+            "admission",
+            "validation",
+            "mutation",
+            "webhook",
+            "kubernetes"
+          ]
         }
       ]
     },
@@ -118,19 +204,40 @@
           "name": "k6-docs",
           "description": "Write or review k6 documentation across TypeScript types (k6-DefinitelyTyped), user docs (k6-docs), and release notes. Use when documenting k6 features, reviewing k6 pull requests for documentation, or writing TypeScript type definitions.",
           "path": "skills/grafana-k6/k6-docs",
-          "tags": ["k6", "load-testing", "documentation", "typescript", "release-notes"]
+          "tags": [
+            "k6",
+            "load-testing",
+            "documentation",
+            "typescript",
+            "release-notes"
+          ]
         },
         {
           "name": "k6-perf-test-website",
           "description": "Performance-test a public website end-to-end with k6. Produces a hybrid protocol+browser test suite, SLO-backed thresholds, a load-generator monitor sidecar, and a Grafana-side investigation playbook. Use when load-testing, stress-testing, or performance-testing a website with k6.",
           "path": "skills/grafana-k6/k6-perf-test-website",
-          "tags": ["k6", "load-testing", "performance", "browser", "slo", "grafana-cloud"]
+          "tags": [
+            "k6",
+            "load-testing",
+            "performance",
+            "browser",
+            "slo",
+            "grafana-cloud"
+          ]
         },
         {
           "name": "k6-manage",
           "description": "Operate Grafana Cloud k6 (GCk6) through the gcx CLI (or direct curl when gcx is unavailable): manage load tests, test runs, scripts, projects, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights; and run scripts locally. Use when listing, creating, or aborting k6 cloud tests, fetching logs or metrics for a run, editing a k6 script, managing project limits or schedules, or calling the /cloud/v6, /cloud/v5, or k6-app Loki endpoints against a Grafana Cloud stack.",
           "path": "skills/grafana-k6/k6-manage",
-          "tags": ["k6", "load-testing", "grafana-cloud", "gcx", "test-runs", "metrics", "logs"]
+          "tags": [
+            "k6",
+            "load-testing",
+            "grafana-cloud",
+            "gcx",
+            "test-runs",
+            "metrics",
+            "logs"
+          ]
         }
       ]
     },
@@ -141,8 +248,12 @@
         {
           "name": "datasources-provisioning",
           "description": "Authoring and schema discovery of grafana data source plugin's configuration",
-          "path": "skills/grafana-datasources/datasource-provisioning",
-          "tags": ["grafana", "plugins", "data-sources"]
+          "path": "skills/grafana-datasources/datasources-provisioning",
+          "tags": [
+            "grafana",
+            "plugins",
+            "data-sources"
+          ]
         }
       ]
     }

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -146,7 +146,7 @@
         }
       ]
     },
-      {
+    {
       "name": "grafana-datasources",
       "description": "Skills for working with Grafana data source plugins",
       "skills": [

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -11,37 +11,31 @@
           "name": "plugin-bundle-size",
           "description": "Optimise Grafana app plugin bundle size using React.lazy, Suspense, and webpack code splitting. Use when the user asks to reduce plugin bundle size, fix large bundles, or split plugin code.",
           "path": "skills/grafana-plugins/plugin-bundle-size",
-          "tags": [
-            "plugins",
-            "bundle-size",
-            "webpack",
-            "react",
-            "performance"
-          ]
+          "tags": ["plugins", "bundle-size", "webpack", "react", "performance"]
         },
         {
           "name": "react-19-plugin-migration",
           "description": "Migrate a Grafana plugin to React 19 compatibility. Use when the user asks to update a plugin for React 19, fix React 19 build errors, or prepare a plugin for Grafana 12.",
           "path": "skills/grafana-plugins/react-19-plugin-migration",
-          "tags": [
-            "plugins",
-            "react",
-            "migration",
-            "react-19"
-          ]
+          "tags": ["plugins", "react", "migration", "react-19"]
         },
         {
           "name": "grafana-scenes",
           "description": "Build Grafana plugin pages using the @grafana/scenes framework. Use when creating scene pages, adding panels, setting up drilldown navigation, defining variables, or working with SceneApp, EmbeddedScene, SceneQueryRunner, or PanelBuilders.",
           "path": "skills/grafana-plugins/grafana-scenes",
-          "tags": [
-            "plugins",
-            "scenes",
-            "react",
-            "grafana-scenes",
-            "drilldown",
-            "panels"
-          ]
+          "tags": ["plugins", "scenes", "react", "grafana-scenes", "drilldown", "panels"]
+        },
+        {
+          "name": "check-npm",
+          "description": "Audit npm, yarn, or pnpm package manager configuration for supply-chain hardening. Use when invoking /check-npm or auditing lifecycle scripts, git dependencies, ignore-scripts, or min-release-age in a Grafana plugin.",
+          "path": "skills/grafana-plugins/check-npm",
+          "tags": ["plugins", "npm", "pnpm", "supply-chain", "security", "dependencies"]
+        },
+        {
+          "name": "audit-and-reduce-dependencies",
+          "description": "Reduce JavaScript dependency footprint with pnpm — remove unused deps, dedupe versions, rank transitive closure, and report Keep/Replace/Remove triage. Use for pnpm dependency cleanup in Grafana plugins.",
+          "path": "skills/grafana-plugins/audit-and-reduce-dependencies",
+          "tags": ["plugins", "pnpm", "dependencies", "supply-chain", "lockfile", "node_modules"]
         }
       ]
     },
@@ -58,27 +52,13 @@
           "name": "dpm-finder",
           "description": "Grafana Professional Services tool for identifying which Prometheus metrics drive high Data Points per Minute (DPM). Analyzes metric-level DPM with per-label breakdown to help optimize Grafana Cloud costs. Use when the user asks about DPM analysis, high-cardinality metrics, metric cost optimization, finding noisy metrics, or running dpm-finder.",
           "path": "skills/grafana-cloud/dpm-finder",
-          "tags": [
-            "grafana-cloud",
-            "dpm",
-            "metrics",
-            "cost-optimization",
-            "prometheus",
-            "professional-services"
-          ]
+          "tags": ["grafana-cloud", "dpm", "metrics", "cost-optimization", "prometheus", "professional-services"]
         },
         {
           "name": "loki-label-analyzer",
           "description": "Expert evaluator for Grafana Loki label strategy. Audits, designs, and improves label schemas using cardinality scoring, access-pattern alignment, static vs. dynamic label rules, and consistency checks. Use when the user asks to evaluate, audit, design, or improve a Loki label strategy — or asks why their Loki queries are slow.",
           "path": "skills/grafana-cloud/loki-label-analyzer",
-          "tags": [
-            "grafana-cloud",
-            "loki",
-            "logs",
-            "labels",
-            "cardinality",
-            "alloy"
-          ]
+          "tags": ["grafana-cloud", "loki", "logs", "labels", "cardinality", "alloy"]
         }
       ]
     },
@@ -90,51 +70,25 @@
           "name": "loki",
           "description": "Grafana Loki log aggregation including LogQL queries, log pipelines, structured metadata, and integration patterns. Use when working with Loki, writing LogQL queries, configuring log pipelines, or discussing log aggregation architecture.",
           "path": "skills/grafana-lgtm/loki",
-          "tags": [
-            "loki",
-            "logs",
-            "logql",
-            "log-aggregation",
-            "logging"
-          ]
+          "tags": ["loki", "logs", "logql", "log-aggregation", "logging"]
         },
         {
           "name": "tempo",
           "description": "Grafana Tempo distributed tracing including TraceQL queries, service graphs, trace correlations, and OpenTelemetry integration. Use when working with Tempo, writing TraceQL queries, configuring trace-to-logs/metrics/profiles, or discussing distributed tracing.",
           "path": "skills/grafana-lgtm/tempo",
-          "tags": [
-            "tempo",
-            "tracing",
-            "traceql",
-            "opentelemetry",
-            "distributed-tracing",
-            "service-graph"
-          ]
+          "tags": ["tempo", "tracing", "traceql", "opentelemetry", "distributed-tracing", "service-graph"]
         },
         {
           "name": "prometheus",
           "description": "Prometheus and Grafana Cloud Metrics including PromQL queries, alerting, recording rules, and integration patterns. Use when working with Prometheus, writing PromQL queries beyond basic usage, configuring Alertmanager, or discussing metrics architecture.",
           "path": "skills/grafana-lgtm/prometheus",
-          "tags": [
-            "prometheus",
-            "mimir",
-            "metrics",
-            "promql",
-            "alerting",
-            "recording-rules"
-          ]
+          "tags": ["prometheus", "mimir", "metrics", "promql", "alerting", "recording-rules"]
         },
         {
           "name": "pyroscope",
           "description": "Grafana Pyroscope continuous profiling including profile types, flame graphs, diff views, and language support. Use when working with Pyroscope, analyzing flame graphs, optimizing code performance, or integrating profiling with traces.",
           "path": "skills/grafana-lgtm/pyroscope",
-          "tags": [
-            "pyroscope",
-            "profiling",
-            "flame-graphs",
-            "performance",
-            "continuous-profiling"
-          ]
+          "tags": ["pyroscope", "profiling", "flame-graphs", "performance", "continuous-profiling"]
         }
       ]
     },
@@ -146,53 +100,25 @@
           "name": "app-sdk-concepts",
           "description": "Grafana App SDK foundational concepts including project initialization, deployment modes (standalone operator, grafana/apps, frontend-only), and the overall development workflow. Use when creating a Grafana app, initializing a grafana-app-sdk project, or asking about deployment modes.",
           "path": "skills/grafana-app-sdk/app-sdk-concepts",
-          "tags": [
-            "app-sdk",
-            "app-platform",
-            "grafana",
-            "kubernetes",
-            "operator",
-            "cue"
-          ]
+          "tags": ["app-sdk", "app-platform", "grafana", "kubernetes", "operator", "cue"]
         },
         {
           "name": "cue-kind-definition",
           "description": "CUE kind definitions and schemas for grafana-app-sdk projects. Use when defining a kind, adding a CUE kind, writing a kind schema, modeling a resource, adding versions, or asking about CUE kind structure, codegen config, spec vs status, or versioning.",
           "path": "skills/grafana-app-sdk/cue-kind-definition",
-          "tags": [
-            "app-sdk",
-            "cue",
-            "kinds",
-            "schema",
-            "codegen",
-            "app-platform"
-          ]
+          "tags": ["app-sdk", "cue", "kinds", "schema", "codegen", "app-platform"]
         },
         {
           "name": "reconciler-logic",
           "description": "Reconciler and watcher business logic for grafana-app-sdk apps. Use when writing a reconciler, implementing async resource processing, handling create/update/delete events, using TypedReconciler, or writing a controller.",
           "path": "skills/grafana-app-sdk/reconciler-logic",
-          "tags": [
-            "app-sdk",
-            "reconciler",
-            "watcher",
-            "kubernetes",
-            "controller",
-            "operator"
-          ]
+          "tags": ["app-sdk", "reconciler", "watcher", "kubernetes", "controller", "operator"]
         },
         {
           "name": "admission-control",
           "description": "Validation and mutation admission handlers for grafana-app-sdk apps. Use when writing a validator, adding admission control, implementing a mutating webhook, validating incoming resources, or asking how to validate or mutate resources before persistence.",
           "path": "skills/grafana-app-sdk/admission-control",
-          "tags": [
-            "app-sdk",
-            "admission",
-            "validation",
-            "mutation",
-            "webhook",
-            "kubernetes"
-          ]
+          "tags": ["app-sdk", "admission", "validation", "mutation", "webhook", "kubernetes"]
         }
       ]
     },
@@ -204,44 +130,23 @@
           "name": "k6-docs",
           "description": "Write or review k6 documentation across TypeScript types (k6-DefinitelyTyped), user docs (k6-docs), and release notes. Use when documenting k6 features, reviewing k6 pull requests for documentation, or writing TypeScript type definitions.",
           "path": "skills/grafana-k6/k6-docs",
-          "tags": [
-            "k6",
-            "load-testing",
-            "documentation",
-            "typescript",
-            "release-notes"
-          ]
+          "tags": ["k6", "load-testing", "documentation", "typescript", "release-notes"]
         },
         {
           "name": "k6-perf-test-website",
           "description": "Performance-test a public website end-to-end with k6. Produces a hybrid protocol+browser test suite, SLO-backed thresholds, a load-generator monitor sidecar, and a Grafana-side investigation playbook. Use when load-testing, stress-testing, or performance-testing a website with k6.",
           "path": "skills/grafana-k6/k6-perf-test-website",
-          "tags": [
-            "k6",
-            "load-testing",
-            "performance",
-            "browser",
-            "slo",
-            "grafana-cloud"
-          ]
+          "tags": ["k6", "load-testing", "performance", "browser", "slo", "grafana-cloud"]
         },
         {
           "name": "k6-manage",
           "description": "Operate Grafana Cloud k6 (GCk6) through the gcx CLI (or direct curl when gcx is unavailable): manage load tests, test runs, scripts, projects, schedules, and env vars; fetch logs, metrics, traces, screenshots, and Cloud Insights; and run scripts locally. Use when listing, creating, or aborting k6 cloud tests, fetching logs or metrics for a run, editing a k6 script, managing project limits or schedules, or calling the /cloud/v6, /cloud/v5, or k6-app Loki endpoints against a Grafana Cloud stack.",
           "path": "skills/grafana-k6/k6-manage",
-          "tags": [
-            "k6",
-            "load-testing",
-            "grafana-cloud",
-            "gcx",
-            "test-runs",
-            "metrics",
-            "logs"
-          ]
+          "tags": ["k6", "load-testing", "grafana-cloud", "gcx", "test-runs", "metrics", "logs"]
         }
       ]
     },
-    {
+      {
       "name": "grafana-datasources",
       "description": "Skills for working with Grafana data source plugins",
       "skills": [

--- a/skills/grafana-datasources/datasources-provisioning/SKILL.md
+++ b/skills/grafana-datasources/datasources-provisioning/SKILL.md
@@ -108,7 +108,9 @@ Worked examples live under `settingsExamples.examples`, an object keyed by scena
 
 If `schema/dsconfig.json` 404s (older plugins):
 
-- Last resort: the generic structure in [grafana-oss](../../grafana-core/grafana-oss/SKILL.md) (§ Data source provisioning) — tell the user the field names are best-effort, not plugin-authoritative.
+- Last resort: the generic structure in **grafana-oss** skill (§ Data source provisioning) can also tell the user the field names are best-effort, not plugin-authoritative.
+
+> NOTE: **grafana-oss** skill is available in `grafana-core` plugin and also available as a standalone skill from the https://github.com/grafana/skills repository
 
 ### 6. Map each field by its `target`
 

--- a/skills/grafana-datasources/datasources-provisioning/SKILL.md
+++ b/skills/grafana-datasources/datasources-provisioning/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: datasource-provisioning
+name: datasources-provisioning
 license: Apache-2.0
 description: Generate a copy-paste Grafana data source provisioning file (YAML or Terraform) for any plugin from its standardized settings schema on the plugins CDN. Use when the user wants to provision or configure a data source as code — e.g. "provision infinity", "datasource yaml for clickhouse", "terraform for the github datasource" — even when they only name the plugin and not the word "provisioning".
 ---
@@ -107,7 +107,8 @@ Worked examples live under `settingsExamples.examples`, an object keyed by scena
 ### 5. Fallback when no schema is published
 
 If `schema/dsconfig.json` 404s (older plugins):
-- Last resort: the generic structure in [grafana-oss](../grafana-oss/SKILL.md) (§ Data source provisioning) — tell the user the field names are best-effort, not plugin-authoritative.
+
+- Last resort: the generic structure in [grafana-oss](../../grafana-core/grafana-oss/SKILL.md) (§ Data source provisioning) — tell the user the field names are best-effort, not plugin-authoritative.
 
 ### 6. Map each field by its `target`
 
@@ -212,4 +213,4 @@ To codify a data source already configured in a running instance, read its confi
 
 ## Related
 
-- [grafana-oss](../grafana-oss/SKILL.md) — generic data source / dashboard provisioning structure and provisioning paths.
+- [grafana-oss](../../grafana-core/grafana-oss/SKILL.md) — generic data source / dashboard provisioning structure and provisioning paths.


### PR DESCRIPTION
This PR fixes the incorrect namespace registered for the `grafana-datasources` skill.

Fixes https://github.com/grafana/skills/issues/66