### PR TITLE
feat(loki-label-analyzer): add cost impact and PS disclaimer to audit reports

### DIFF
--- a/skills/grafana-cloud/loki-label-analyzer/SKILL.md
+++ b/skills/grafana-cloud/loki-label-analyzer/SKILL.md
@@ -63,7 +63,7 @@ For each label, ask:
 
 ## Evaluation Output Format
 
-When auditing a label set, produce a report in this structure. Every audit report **must** start with the Disclaimer (verbatim), and **must** include Cost Impact Analysis when Grafana Cloud usage metrics are available; if they are not, state what is missing and still give qualitative A/B/C guidance (see [Cost Impact Analysis](#cost-impact-analysis)).
+When auditing a label set, produce a report in this structure. Every audit report **must** start with the Disclaimer (verbatim), and **must** include Cost Impact Analysis when Grafana Cloud usage metrics are available; if they are not, state what is missing and still give qualitative A/B/C guidance. Load [references/cost-impact.md](references/cost-impact.md) when filling that section.
 
 ```
 ## Loki Label Strategy Audit
@@ -404,74 +404,7 @@ stage.labels { values = { team = "" } }
 
 ## Log Line Optimization
 
-These reduce storage costs. Establish a cost-per-GB baseline before implementing.
-
-### Remove Timestamps from Log Lines
-
-Each log entry already has a metadata timestamp — the inline timestamp is redundant (~30–34 bytes each, ~6% of a typical log line).
-
-```alloy
-loki.process "drop_timestamp" {
- forward_to = [...]
- // logfmt timestamps
- stage.replace {
- expression = "(?i)((?:time_?(?:stamp)?|ts|logdate|start_?time)=[^ \\n]+(?: |$))"
- replace = " "
- }
- // JSON timestamps
- stage.replace {
- expression = "(\"@?(?:time_?(?:stamp)?|ts|logdate|start_?time)\"\\s*:\\s*\"[^\"]+\",?)"
- replace = " "
- }
- // ISO-8601 at start of line
- stage.replace {
- expression = "^(\\d{4}-\\d{2}-\\d{2})T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,9})?Z?)?"
- replace = ""
- }
-}
-```
-
-The original timestamp is still accessible at query time: `| line_format '{{ __timestamp__ | date "2006-01-02T15:04:05Z" }}'`
-
-### Remove ANSI Color Codes
-
-```alloy
-loki.process "decolorize" {
- forward_to = [...]
- stage.decolorize {}
-}
-```
-
-### Remove Duplicate Level Field (when `level` is already a label)
-
-```alloy
-stage.replace { expression = "(level=[^ ]+ )"; replace = "" }
-```
-
-### JSON Optimizations
-
-```alloy
-// Remove null values
-stage.replace {
- expression = "(\\s*(\"[^\"]+\"\\s*:\\s*null)(?:\\s*,)?\\s*)"
- replace = ""
-}
-
-// Remove placeholder values ("-", "undefined", "null" strings)
-stage.replace {
- expression = "(\\s*(\"[^\"]+\"\\s*:\\s*\"(?:-|null|undefined)\")(?:\\s*,)?\\s*)"
- replace = ""
-}
-
-// Remove empty values ("", [], {})
-stage.replace {
- expression = "(\\s*,\\s*(\"[^\"]+\"\\s*:\\s*(\\[\\s*\\]|\\{\\s*\\}|\"\\s*\"))|(\"[^\"]+\"\\s*:\\s*(\\[\\s*\\]|\\{\\s*\\}|\"\\s*\"))\\s*,\\s*)"
- replace = ""
-}
-```
-
-**Practical savings** (Istio access log example):
-Starting at 753 bytes (minified) → after removing nulls, placeholders, unused fields, normalizing keys: **464 bytes — 38% reduction**.
+Byte-level reductions (timestamps, ANSI, null JSON fields) for Scenario C savings — see [references/log-line-optimization.md](references/log-line-optimization.md).
 
 ---
 
@@ -517,63 +450,4 @@ Focus on these before anything else.
 
 ## Cost Impact Analysis
 
-### How label changes translate to billing
-
-Label cardinality changes (removing high-churn labels such as `pod`, raw `filename`, optionally `node`, plus duplicate/constant labels) do not reduce ingested bytes directly. Loki bills on compressed bytes ingested, not on stream count. Do **not** treat `instance` as a default removal — it is acceptable for fixed Host/VM infrastructure when it matches access patterns. What high-cardinality labels _do_ inflate is:
-
-* **Index storage** — each unique label combination creates a TSDB index entry; more streams = larger index = higher memory and storage overhead
-* **Query compute** — scanning across thousands of streams is slower and consumes more Querier CPU
-
-The billing-visible savings come from changes that label cleanup _enables_:
-
-1. Normalize `level` first — once `level` has 5 stable lowercase values, a `stage.drop` in Alloy can discard `debug` and `trace` streams before ingest. Debug/trace often accounts for 20–40% of volume in verbose K8s workloads. **Guardrail:** only recommend dropping debug/trace after explicit customer confirmation; prefer env scoping (e.g. drop only when `env=prod`) or sampling rather than a blanket drop.
-2. Log-line optimization — removing embedded timestamps (redundant with Loki's metadata timestamp), ANSI color codes, null/empty JSON fields, and duplicate level fields reduces per-line byte size. Observed savings are typically 15–38%; the 38% figure is from the Istio access-log example in Log Line Optimization, not a universal expectation.
-
-### Savings scenarios
-
-Percentages below are **illustrative defaults**. Replace them with measured values from the Grafana Cloud usage metrics datasource (not the customer's Loki datasource) using `grafanacloud_logs_instance_billable_bytes_received_per_second` and `grafanacloud_org_logs_overage`, then apply the contract per-GB rate.
-
-| Scenario | Actions | Stream reduction | Volume reduction | Est. monthly savings¹ | Overage impact |
-|---|---|---|---|---|---|
-| A — Label hygiene only | Remove high-churn K8s labels (`pod`, raw `filename`, optionally `node`); drop duplicate + constant labels | ~−65 to −75% (illustrative) | 0% | $0 direct² | None |
-| B — Level fix + debug/trace drop | Scenario A + normalize level + `stage.drop` for debug/trace (**only if customer-approved / env-scoped**) | ~−75% (illustrative) | ~−25% (illustrative) | ~25% of monthly bill (replace with measured) | Often reduced or eliminated |
-| C — Full optimization | Scenario B + log-line cleanup (timestamps, nulls, ANSI) | ~−80% (illustrative) | ~−38% (Istio example ceiling) | ~volume reduction % of monthly bill | Eliminated + net savings (when measured) |
-
-¹ Apply contract per-GB rate to `monthly_volume_GB × reduction_%` for a dollar figure.
-² Scenario A produces **indirect** value: smaller index, lower Loki memory pressure, reduced query timeout risk, and avoidance of stream-count ingestion throttling limits.
-
-### Cost attribution prerequisite
-
-Grafana Cloud cost attribution uses **customer-configured** attribution label(s) (often `team`, `service`, or `env` — check Cost Management → Settings; up to two labels). Soft-enforce whichever label is configured (see Soft Enforcement under Alloy / Agent Configuration Patterns), not a hard-coded `owner`.
-
-Check unattributed volume (substitute the configured label for `<attr_label>`; `__missing__` only appears when attribution is enabled):
-
-```PromQL
-sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
-```
-
-A high `__missing__` (or unlabeled) share means most overage cannot be assigned to a team. Soft-enforce the configured label with `stage.template` to inject `unknown` when absent, then work with teams to populate it correctly.
-
-### Measuring baseline before and after
-
-Query these against the **Grafana Cloud billing/usage metrics** datasource before changes, then again ~7 days after deploying the Alloy pipeline:
-
-```PromQL
-# Billable ingestion rate (bytes/s)
-grafanacloud_logs_instance_billable_bytes_received_per_second
-
-# Active stream count
-grafanacloud_logs_instance_active_streams
-
-# Current period monetary overage
-grafanacloud_org_logs_overage{monetary="true"}
-
-# Volume by configured attribution label (identifies unattributed share)
-sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
-```
-
-Convert the ingestion rate to a monthly volume equivalent:
-
-```
-monthly_GB = bytes_per_second × 86400 × 30 / 1e9
-```
+Label hygiene alone does not cut billable ingest bytes ($0 direct). Volume savings come from enabled `stage.drop` / log-line cleanup. For A/B/C scenarios, attribution labels, and baseline PromQL against the Grafana Cloud usage metrics datasource, load [references/cost-impact.md](references/cost-impact.md) when writing the report's Cost Impact Analysis section.

--- a/skills/grafana-cloud/loki-label-analyzer/SKILL.md
+++ b/skills/grafana-cloud/loki-label-analyzer/SKILL.md
@@ -63,10 +63,25 @@ For each label, ask:
 
 ## Evaluation Output Format
 
-When auditing a label set, produce a report in this structure:
+When auditing a label set, produce a report in this structure. Every audit report **must** start with the Disclaimer (verbatim), and **must** include Cost Impact Analysis when Grafana Cloud usage metrics are available; if they are not, state what is missing and still give qualitative A/B/C guidance (see [Cost Impact Analysis](#cost-impact-analysis)).
 
 ```
 ## Loki Label Strategy Audit
+
+### Disclaimer
+
+This report is Confidential Information of Raintank, Inc. dba Grafana Labs
+(“Grafana Labs”), furnished for informational purposes only. It is not part of
+Grafana Labs product documentation, is not a substitute for official docs or
+Support, and is provided “as is” without warranties as to accuracy,
+completeness, or suitability.
+
+Recommendations were prepared by Grafana Labs Professional Services from
+domain expertise. They are a starting point, not definitive or universally
+applicable solutions. Every environment is unique — examine, adapt, and
+validate before implementing. Grafana Labs and Raintank, Inc. are not liable
+for damages arising from use of these recommendations. You remain responsible
+for implementation decisions and for keeping practices current.
 
 ### Summary
 [1-2 sentence overall assessment]
@@ -81,6 +96,13 @@ When auditing a label set, produce a report in this structure:
 - Stream count reduction: [X streams → Y streams]
 - Query performance: [describe improvement]
 - Storage impact: [if log line changes are involved]
+
+### Cost Impact Analysis
+- Billing note: label hygiene alone → $0 direct ingest savings; volume savings from enabled drops / line optimization
+- Baseline: billable bytes/s, active streams, overage (from Grafana Cloud usage metrics datasource)
+- Scenarios A/B/C with **measured** volumes and estimated monthly $ (or % of bill if rate unknown)
+- Attribution gap: share missing the configured cost-attribution label
+- Caveats: replace illustrative % with measured values; recommend debug/trace drop only with explicit customer confirmation / env scoping
 
 ### Recommended Label Set
 [Final recommended labels]
@@ -490,3 +512,68 @@ Focus on these before anything else.
 | `filename` (raw K8s path) | Contains pod UID | Normalize or drop |
 | Unnormalized `level` | `INFO`/`info`/`Info` = 3 streams | Normalize at collection time |
 | Any dynamically-named label key | Cannot be bounded | Use fixed keys with bounded values |
+
+---
+
+## Cost Impact Analysis
+
+### How label changes translate to billing
+
+Label cardinality changes (removing high-churn labels such as `pod`, raw `filename`, optionally `node`, plus duplicate/constant labels) do not reduce ingested bytes directly. Loki bills on compressed bytes ingested, not on stream count. Do **not** treat `instance` as a default removal — it is acceptable for fixed Host/VM infrastructure when it matches access patterns. What high-cardinality labels _do_ inflate is:
+
+* **Index storage** — each unique label combination creates a TSDB index entry; more streams = larger index = higher memory and storage overhead
+* **Query compute** — scanning across thousands of streams is slower and consumes more Querier CPU
+
+The billing-visible savings come from changes that label cleanup _enables_:
+
+1. Normalize `level` first — once `level` has 5 stable lowercase values, a `stage.drop` in Alloy can discard `debug` and `trace` streams before ingest. Debug/trace often accounts for 20–40% of volume in verbose K8s workloads. **Guardrail:** only recommend dropping debug/trace after explicit customer confirmation; prefer env scoping (e.g. drop only when `env=prod`) or sampling rather than a blanket drop.
+2. Log-line optimization — removing embedded timestamps (redundant with Loki's metadata timestamp), ANSI color codes, null/empty JSON fields, and duplicate level fields reduces per-line byte size. Observed savings are typically 15–38%; the 38% figure is from the Istio access-log example in Log Line Optimization, not a universal expectation.
+
+### Savings scenarios
+
+Percentages below are **illustrative defaults**. Replace them with measured values from the Grafana Cloud usage metrics datasource (not the customer's Loki datasource) using `grafanacloud_logs_instance_billable_bytes_received_per_second` and `grafanacloud_org_logs_overage`, then apply the contract per-GB rate.
+
+| Scenario | Actions | Stream reduction | Volume reduction | Est. monthly savings¹ | Overage impact |
+|---|---|---|---|---|---|
+| A — Label hygiene only | Remove high-churn K8s labels (`pod`, raw `filename`, optionally `node`); drop duplicate + constant labels | ~−65 to −75% (illustrative) | 0% | $0 direct² | None |
+| B — Level fix + debug/trace drop | Scenario A + normalize level + `stage.drop` for debug/trace (**only if customer-approved / env-scoped**) | ~−75% (illustrative) | ~−25% (illustrative) | ~25% of monthly bill (replace with measured) | Often reduced or eliminated |
+| C — Full optimization | Scenario B + log-line cleanup (timestamps, nulls, ANSI) | ~−80% (illustrative) | ~−38% (Istio example ceiling) | ~volume reduction % of monthly bill | Eliminated + net savings (when measured) |
+
+¹ Apply contract per-GB rate to `monthly_volume_GB × reduction_%` for a dollar figure.
+² Scenario A produces **indirect** value: smaller index, lower Loki memory pressure, reduced query timeout risk, and avoidance of stream-count ingestion throttling limits.
+
+### Cost attribution prerequisite
+
+Grafana Cloud cost attribution uses **customer-configured** attribution label(s) (often `team`, `service`, or `env` — check Cost Management → Settings; up to two labels). Soft-enforce whichever label is configured (see Soft Enforcement under Alloy / Agent Configuration Patterns), not a hard-coded `owner`.
+
+Check unattributed volume (substitute the configured label for `<attr_label>`; `__missing__` only appears when attribution is enabled):
+
+```PromQL
+sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
+```
+
+A high `__missing__` (or unlabeled) share means most overage cannot be assigned to a team. Soft-enforce the configured label with `stage.template` to inject `unknown` when absent, then work with teams to populate it correctly.
+
+### Measuring baseline before and after
+
+Query these against the **Grafana Cloud billing/usage metrics** datasource before changes, then again ~7 days after deploying the Alloy pipeline:
+
+```PromQL
+# Billable ingestion rate (bytes/s)
+grafanacloud_logs_instance_billable_bytes_received_per_second
+
+# Active stream count
+grafanacloud_logs_instance_active_streams
+
+# Current period monetary overage
+grafanacloud_org_logs_overage{monetary="true"}
+
+# Volume by configured attribution label (identifies unattributed share)
+sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
+```
+
+Convert the ingestion rate to a monthly volume equivalent:
+
+```
+monthly_GB = bytes_per_second × 86400 × 30 / 1e9
+```

--- a/skills/grafana-cloud/loki-label-analyzer/references/cost-impact.md
+++ b/skills/grafana-cloud/loki-label-analyzer/references/cost-impact.md
@@ -1,0 +1,64 @@
+# Cost Impact Analysis
+
+Fill the report's **Cost Impact Analysis** section from measured Grafana Cloud usage metrics. Percentages below are illustrative — replace with measured values and the contract per-GB rate.
+
+## How label changes translate to billing
+
+Label cardinality changes (removing high-churn labels such as `pod`, raw `filename`, optionally `node`, plus duplicate/constant labels) do not reduce ingested bytes directly. Loki bills on compressed bytes ingested, not on stream count. Do **not** treat `instance` as a default removal — it is acceptable for fixed Host/VM infrastructure when it matches access patterns. What high-cardinality labels _do_ inflate is:
+
+* **Index storage** — each unique label combination creates a TSDB index entry; more streams = larger index = higher memory and storage overhead
+* **Query compute** — scanning across thousands of streams is slower and consumes more Querier CPU
+
+The billing-visible savings come from changes that label cleanup _enables_:
+
+1. Normalize `level` first — once `level` has 5 stable lowercase values, a `stage.drop` in Alloy can discard `debug` and `trace` streams before ingest. Debug/trace often accounts for 20–40% of volume in verbose K8s workloads. **Guardrail:** only recommend dropping debug/trace after explicit customer confirmation; prefer env scoping (e.g. drop only when `env=prod`) or sampling rather than a blanket drop.
+2. Log-line optimization — removing embedded timestamps, ANSI color codes, null/empty JSON fields, and duplicate level fields. Observed savings are typically 15–38%; the 38% figure is from the Istio example in [log-line-optimization.md](log-line-optimization.md), not a universal expectation.
+
+## Savings scenarios
+
+Replace illustrative percentages with measured values from the Grafana Cloud usage metrics datasource (not the customer's Loki datasource) using `grafanacloud_logs_instance_billable_bytes_received_per_second` and `grafanacloud_org_logs_overage`, then apply the contract per-GB rate.
+
+| Scenario | Actions | Stream reduction | Volume reduction | Est. monthly savings¹ | Overage impact |
+|---|---|---|---|---|---|
+| A — Label hygiene only | Remove high-churn K8s labels (`pod`, raw `filename`, optionally `node`); drop duplicate + constant labels | ~−65 to −75% (illustrative) | 0% | $0 direct² | None |
+| B — Level fix + debug/trace drop | Scenario A + normalize level + `stage.drop` for debug/trace (**only if customer-approved / env-scoped**) | ~−75% (illustrative) | ~−25% (illustrative) | ~25% of monthly bill (replace with measured) | Often reduced or eliminated |
+| C — Full optimization | Scenario B + log-line cleanup (timestamps, nulls, ANSI) | ~−80% (illustrative) | ~−38% (Istio example ceiling) | ~volume reduction % of monthly bill | Eliminated + net savings (when measured) |
+
+¹ Apply contract per-GB rate to `monthly_volume_GB × reduction_%` for a dollar figure.
+² Scenario A produces **indirect** value: smaller index, lower Loki memory pressure, reduced query timeout risk, and avoidance of stream-count ingestion throttling limits.
+
+## Cost attribution prerequisite
+
+Grafana Cloud cost attribution uses **customer-configured** attribution label(s) (often `team`, `service`, or `env` — check Cost Management → Settings; up to two labels). Soft-enforce whichever label is configured (see Soft Enforcement in the skill body), not a hard-coded `owner`.
+
+Check unattributed volume (substitute the configured label for `<attr_label>`; `__missing__` only appears when attribution is enabled):
+
+```PromQL
+sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
+```
+
+A high `__missing__` (or unlabeled) share means most overage cannot be assigned to a team. Soft-enforce the configured label with `stage.template` to inject `unknown` when absent, then work with teams to populate it correctly.
+
+## Measuring baseline before and after
+
+Query these against the **Grafana Cloud billing/usage metrics** datasource before changes, then again ~7 days after deploying the Alloy pipeline:
+
+```PromQL
+# Billable ingestion rate (bytes/s)
+grafanacloud_logs_instance_billable_bytes_received_per_second
+
+# Active stream count
+grafanacloud_logs_instance_active_streams
+
+# Current period monetary overage
+grafanacloud_org_logs_overage{monetary="true"}
+
+# Volume by configured attribution label (identifies unattributed share)
+sum by (<attr_label>) (grafanacloud_logs_instance_attributed_bytes_received_per_second)
+```
+
+Convert the ingestion rate to a monthly volume equivalent:
+
+```
+monthly_GB = bytes_per_second × 86400 × 30 / 1e9
+```

--- a/skills/grafana-cloud/loki-label-analyzer/references/log-line-optimization.md
+++ b/skills/grafana-cloud/loki-label-analyzer/references/log-line-optimization.md
@@ -1,0 +1,70 @@
+# Log Line Optimization
+
+These reduce storage costs (Scenario C in [cost-impact.md](cost-impact.md)). Establish a cost-per-GB baseline before implementing.
+
+## Remove Timestamps from Log Lines
+
+Each log entry already has a metadata timestamp — the inline timestamp is redundant (~30–34 bytes each, ~6% of a typical log line).
+
+```alloy
+loki.process "drop_timestamp" {
+ forward_to = [...]
+ // logfmt timestamps
+ stage.replace {
+ expression = "(?i)((?:time_?(?:stamp)?|ts|logdate|start_?time)=[^ \\n]+(?: |$))"
+ replace = " "
+ }
+ // JSON timestamps
+ stage.replace {
+ expression = "(\"@?(?:time_?(?:stamp)?|ts|logdate|start_?time)\"\\s*:\\s*\"[^\"]+\",?)"
+ replace = " "
+ }
+ // ISO-8601 at start of line
+ stage.replace {
+ expression = "^(\\d{4}-\\d{2}-\\d{2})T\\d{2}:\\d{2}(?::\\d{2}(?:\\.\\d{1,9})?Z?)?"
+ replace = ""
+ }
+}
+```
+
+The original timestamp is still accessible at query time: `| line_format '{{ __timestamp__ | date "2006-01-02T15:04:05Z" }}'`
+
+## Remove ANSI Color Codes
+
+```alloy
+loki.process "decolorize" {
+ forward_to = [...]
+ stage.decolorize {}
+}
+```
+
+## Remove Duplicate Level Field (when `level` is already a label)
+
+```alloy
+stage.replace { expression = "(level=[^ ]+ )"; replace = "" }
+```
+
+## JSON Optimizations
+
+```alloy
+// Remove null values
+stage.replace {
+ expression = "(\\s*(\"[^\"]+\"\\s*:\\s*null)(?:\\s*,)?\\s*)"
+ replace = ""
+}
+
+// Remove placeholder values ("-", "undefined", "null" strings)
+stage.replace {
+ expression = "(\\s*(\"[^\"]+\"\\s*:\\s*\"(?:-|null|undefined)\")(?:\\s*,)?\\s*)"
+ replace = ""
+}
+
+// Remove empty values ("", [], {})
+stage.replace {
+ expression = "(\\s*,\\s*(\"[^\"]+\"\\s*:\\s*(\\[\\s*\\]|\\{\\s*\\}|\"\\s*\"))|(\"[^\"]+\"\\s*:\\s*(\\[\\s*\\]|\\{\\s*\\}|\"\\s*\"))\\s*,\\s*)"
+ replace = ""
+}
+```
+
+**Practical savings** (Istio access log example):
+Starting at 753 bytes (minified) → after removing nulls, placeholders, unused fields, normalizing keys: **464 bytes — 38% reduction**.


### PR DESCRIPTION
## Summary
- Require every Loki Label Strategy Audit report to open with a trimmed Professional Services disclaimer (informational / as-is / validate for your environment).
- Add a **Cost Impact Analysis** section to the report template, backed by new skill guidance on how label hygiene vs. volume reductions map to Grafana Cloud Logs billing.
- Document illustrative A→B→C savings scenarios, baseline usage-metric queries, and configured cost-attribution labels (not a hard-coded `owner`), including guardrails for debug/trace drops.

## Motivation
After running this skill on a customer Grafana Cloud stack, feedback asked for:
1. Cost impact analysis in the skill report
2. A disclaimer at the top of the report covering responsibility criteria for responsible AI / PS guidance

## Test plan
- [ ] Run `./scripts/lint-skills.sh skills/grafana-cloud` (expect pass; line-count warning on this skill is ok)
- [ ] Spot-check that Evaluation Output Format lists Disclaimer first, then Cost Impact Analysis after Estimated Impact
- [ ] Optionally re-run `/loki-label-analyzer` (or equivalent) on a Cloud stack and confirm the produced report includes both sections