### PR TITLE
Add CODEOWNERS for skills/grafana-k6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+skills/grafana-k6/ @ankur22 @inancgumus @vortegatorres @andrewslotin


### PR DESCRIPTION
Adds `.github/CODEOWNERS` scoping review ownership for the `skills/grafana-k6/` directory.

## Files

| File | Change |
|------|--------|
| `.github/CODEOWNERS` | New file. Maps `skills/grafana-k6/` to `@ankur22 @inancgumus @vortegatorres @andrewslotin` |

No other paths are covered by this rule, so PRs outside `skills/grafana-k6/` won't require review from these owners.