### PR TITLE
ci: validate marketplace skill paths

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,16 +16,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Validate JSON syntax
-        run: |
-          echo "Validating Claude Code marketplace.json..."
-          jq empty .claude-plugin/marketplace.json
-
-          echo "Validating Cursor marketplace.json..."
-          jq empty .cursor-plugin/marketplace.json
-
-          echo "Validating Codex marketplace.json..."
-          jq empty .agents-plugin/marketplace.json
+      - name: Validate marketplace manifests
+        run: ./scripts/validate-marketplace.sh
 
       - name: Validate marketplace structure
         run: |

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Validate marketplace manifests and their declared skill directories.
+
+set -euo pipefail
+
+MANIFESTS=(
+  ".claude-plugin/marketplace.json"
+  ".cursor-plugin/marketplace.json"
+  ".agents-plugin/marketplace.json"
+)
+PRIMARY_MANIFEST="${MANIFESTS[0]}"
+
+for manifest in "${MANIFESTS[@]}"; do
+  echo "Validating JSON syntax: $manifest"
+  jq empty "$manifest"
+done
+
+for manifest in "${MANIFESTS[@]:1}"; do
+  if ! cmp -s "$PRIMARY_MANIFEST" "$manifest"; then
+    echo "ERROR: $manifest differs from $PRIMARY_MANIFEST"
+    diff -u "$PRIMARY_MANIFEST" "$manifest" || true
+    exit 1
+  fi
+done
+echo "Marketplace manifests are identical"
+
+duplicate_paths=$(jq -r '.plugins[].skills[]' "$PRIMARY_MANIFEST" | sort | uniq -d)
+if [ -n "$duplicate_paths" ]; then
+  echo "ERROR: Duplicate skill paths in $PRIMARY_MANIFEST:"
+  echo "$duplicate_paths"
+  exit 1
+fi
+
+missing_paths=0
+while IFS= read -r declared_path; do
+  skill_path=${declared_path#./}
+  if [ ! -f "$skill_path/SKILL.md" ]; then
+    echo "ERROR: Marketplace skill path does not contain SKILL.md: $declared_path"
+    missing_paths=$((missing_paths + 1))
+  fi
+done < <(jq -r '.plugins[].skills[]' "$PRIMARY_MANIFEST")
+
+if [ "$missing_paths" -gt 0 ]; then
+  exit 1
+fi
+
+skill_count=$(jq '[.plugins[].skills[]] | length' "$PRIMARY_MANIFEST")
+echo "Validated $skill_count marketplace skill paths"


### PR DESCRIPTION
## Summary

- add a reusable marketplace validation script
- require the Claude Code, Cursor, and Codex manifests to remain identical
- verify every declared skill path exists, contains `SKILL.md`, and is not duplicated
- run the stronger validation in the existing marketplace CI workflow

## Why

#59 was caused by a marketplace entry pointing at a non-existent skill directory. The direct manifest fix landed in #71, but the existing CI only checks JSON syntax and version consistency, so the same class of path mismatch could recur unnoticed.

This follow-up turns that failure mode into a CI error while preserving the current marketplace structure.

## Impact

No skill content or runtime behavior changes. Contributors get an actionable validation error when a marketplace manifest drifts or references a missing skill.

Closes #59.
