### PR TITLE
fix(loki-label-analyzer): never drop Grafana Cloud correlation labels

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Get Tessl token from Vault
         id: get-secrets
         # Tessl API token (from https://tessl.io workspace settings) maintained
-        # in Grafana's dev Vault. The action no longer exports secrets as env
-        # vars by default; we forward TESSL_TOKEN explicitly on the review step.
+        # in Grafana's dev Vault. Passed into skill-review via the tessl-token
+        # input (required by setup-tessl@v2).
         uses: grafana/shared-workflows/actions/get-vault-secrets@e378ca000c6166a44060ed3a3c987a53da14128d # main
         with:
           vault_instance: dev
@@ -53,15 +53,14 @@ jobs:
         # Older pins crash with String.prototype.repeat RangeError when a
         # dimension score exceeds the old hardcoded max of 3.
         uses: tesslio/skill-review@5aefcf5e500ae13a9af904383dbb914c6c3a50e4 # main @ 2026-07-22
-        env:
-          # TESSL_TOKEN forwarded so the action keeps working when setup-tessl@v1
-          # is phased out for @v2 (token-required).
-          TESSL_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).TESSL_TOKEN }}
         with:
           comment: 'false'
           # Block PR merge on scores below 75. Anthropic best-practice baseline
           # is ~80; 75 leaves some room for rubric noise without being lax.
           fail-threshold: 75
+          # setup-tessl@v2 (pulled in by this action pin) requires the token as
+          # an action input — env TESSL_TOKEN alone is not enough to log in.
+          tessl-token: ${{ fromJSON(steps.get-secrets.outputs.secrets).TESSL_TOKEN }}
 
   fork-pr-notice:
     runs-on: ubuntu-latest

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -49,7 +49,10 @@ jobs:
       # provisioned in deployment_tools — see follow-up. Until then, scores
       # appear in the run log and the status check still gates merges.
       - name: Run Tessl Skill Review
-        uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main @ 2026-03-27
+        # Pin includes scoreBar fix for rubric scale 1-5 (tesslio/skill-review#18).
+        # Older pins crash with String.prototype.repeat RangeError when a
+        # dimension score exceeds the old hardcoded max of 3.
+        uses: tesslio/skill-review@5aefcf5e500ae13a9af904383dbb914c6c3a50e4 # main @ 2026-07-22
         env:
           # TESSL_TOKEN forwarded so the action keeps working when setup-tessl@v1
           # is phased out for @v2 (token-required).

--- a/skills/grafana-cloud/loki-label-analyzer/SKILL.md
+++ b/skills/grafana-cloud/loki-label-analyzer/SKILL.md
@@ -25,7 +25,9 @@ You are an expert in Grafana Loki label strategy. When asked to evaluate, audit,
 - **Ingestion path**: More streams → larger index, higher storage costs
 - **Query path**: If a high-cardinality label exists but isn't in the query selector, Loki must scan ALL streams matching the other selectors — catastrophic for performance
 
-**The key question for any dynamic label**: "Will this label be used in 9 out of 10 queries?" If no → it should NOT be a label.
+**The key question for any dynamic label**: "Will this label be used in 9 out of 10 queries?" If no → it should NOT be a label — **except** platform / correlation labels (below).
+
+**Platform / correlation labels are exempt from drop recommendations.** Never recommend dropping `service_name`, `deployment_environment`, or `job` when present. Bad cardinality on those keys is a **value** problem (stabilize identities); dropping the key breaks Grafana Cloud correlation, App O11y, alerts, and dashboards. Load [references/protected-labels.md](references/protected-labels.md) before any demote/`label_keep` advice.
 
 ---
 
@@ -37,18 +39,21 @@ When auditing a label strategy, assess each label against these criteria.
 
 | Label Example | Cardinality | Verdict |
 |---|---|---|
+| `service_name` / `deployment_environment` / `job` | Any | ✅ Keep key — remediate values if high-card (never drop) |
 | `env` (prod/staging/dev) | 2–5 values | ✅ Good |
 | `level` (info/warn/error) | 3–6 values | ✅ Good |
 | `namespace` (K8s) | Tens | ✅ Acceptable |
 | `instance` / `hostname` | Hundreds–thousands | ⚠️ Evaluate access patterns |
-| `pod` | Thousands + transient | ❌ Avoid as label |
+| `pod` | Thousands + transient | ⚠️ Demote off index (structured metadata) — migrate selectors first |
 | `user_id`, `request_id` | Unbounded | ❌ Never use as label |
 
 ### Access Pattern Alignment
 For each label, ask:
+- Is this label on the protected allowlist? If yes → Keep key; remediate values only ([protected-labels.md](references/protected-labels.md))
 - Is this label used as a selector in most queries targeting these logs?
 - Does this label logically segment data in the way users think about it?
-- Would removing this label force users to scan dramatically more data?
+- Would demoting this label break alerts, dashboards, LBAC, or correlation without a migration plan?
+- Would demoting this label force users to scan dramatically more data?
 
 ### Static vs. Dynamic Label Values
 - **Static labels** (values don't change per log line, e.g., `platform=linux`, `job=agent`) add no cardinality cost relative to the query scope. Use freely for LBAC, exploration, and alert routing.
@@ -68,9 +73,10 @@ When auditing a label set, produce a report in the structure below.
 **Hard requirements before finalizing any audit report:**
 
 1. **Disclaimer (mandatory, first body section):** Load [references/disclaimer.md](references/disclaimer.md) and paste its two paragraphs **verbatim** under a `### Disclaimer` heading. An empty Disclaimer heading is a failed report — do not ship the audit until both paragraphs are present. Never paraphrase, summarize, or omit this text.
-2. **Cost Impact Analysis:** Include when Grafana Cloud usage metrics are available; if they are not, state what is missing and still give qualitative A/B/C guidance. Load [references/cost-impact.md](references/cost-impact.md) and follow its **Required report shape** (scenario cards). Do **not** paste markdown tables or panel/query JSON into this section.
+2. **Protected labels:** Before recommending demote/drop for any label, load [references/protected-labels.md](references/protected-labels.md). Never recommend dropping `service_name`, `deployment_environment`, or `job` when present — only value remediation. Include a **Downstream dependency check** covering alerts, dashboards, LBAC, and correlation.
+3. **Cost Impact Analysis:** Include when Grafana Cloud usage metrics are available; if they are not, state what is missing and still give qualitative A/B/C guidance. Load [references/cost-impact.md](references/cost-impact.md) and follow its **Required report shape** (scenario cards). Do **not** paste markdown tables or panel/query JSON into this section.
 
-**Report completion check:** Before delivering, confirm (a) the output contains the substring `Confidential Information of Raintank, Inc.` immediately after `### Disclaimer`, and (b) Cost Impact Analysis uses scenario cards (A/B/C) with a **Billing note** opener and a bullet **Measured baseline** — not a scenario table and not `panelId`/`targets` JSON. If (a) is missing, paste from [references/disclaimer.md](references/disclaimer.md) and re-emit. If (b) fails, rewrite Cost Impact from [references/cost-impact.md](references/cost-impact.md).
+**Report completion check:** Before delivering, confirm (a) the output contains the substring `Confidential Information of Raintank, Inc.` immediately after `### Disclaimer`, (b) Cost Impact Analysis uses scenario cards (A/B/C) with a **Billing note** opener and a bullet **Measured baseline** — not a scenario table and not `panelId`/`targets` JSON, and (c) no Action cell recommends dropping an allowlisted correlation label. If (a) is missing, paste from [references/disclaimer.md](references/disclaimer.md) and re-emit. If (b) fails, rewrite Cost Impact from [references/cost-impact.md](references/cost-impact.md). If (c) fails, rewrite Actions per [references/protected-labels.md](references/protected-labels.md).
 
 ```
 ## Loki Label Strategy Audit
@@ -81,16 +87,22 @@ When auditing a label set, produce a report in the structure below.
 ### Summary
 [1-2 sentence overall assessment]
 
+### Downstream dependency check
+[Alerts / dashboards / LBAC / correlation that select on labels proposed for demote or rename — or "unknown; confirm with customer before cutover"]
+
 ### Label Analysis
 | Label | Cardinality | Used in Queries? | Verdict | Action |
 |---|---|---|---|---|
-| app | Low (tens) | Always | ✅ Keep | — |
-| pod | Very High (transient)| Rarely | ❌ Remove | Move to structured metadata or embed in log line |
+| service_name | High (UUID values) | Always | ✅ Keep key | Stabilize values to durable service identity — do not drop label |
+| deployment_environment | Low | Often | ✅ Keep | — |
+| job | Low–medium | Often | ✅ Keep | — |
+| pod | Very High (transient)| Rarely | ⚠️ Demote | Move to structured metadata or embed; migrate selectors first |
 
 ### Estimated Impact
 - Stream count reduction: [X streams → Y streams]
 - Query performance: [describe improvement]
 - Storage impact: [if log line changes are involved]
+- Correlation impact: [none if allowlist preserved; call out if aliases need dual-write]
 
 ### Cost Impact Analysis
 [Follow references/cost-impact.md Required report shape — do not invent a table]
@@ -117,10 +129,10 @@ Stream count and query cost improve; ingest $ drops only when volume is reduced.
 **Caveats:** [...]
 
 ### Recommended Label Set
-[Final recommended labels]
+[Final recommended labels — must include service_name, deployment_environment, job when present]
 
 ### Migration Notes
-[How to implement changes via Alloy/Agent pipeline stages]
+[How to implement changes via Alloy/Agent pipeline stages; dual-write / selector updates for any demote or rename]
 ```
 
 ---
@@ -131,15 +143,19 @@ Every log source should consider these base labels — all low cardinality, high
 
 | Label | Purpose |
 |---|---|
-| `app` / `service` | Identifying the generating application |
-| `env` | Environment (prod, staging, dev) |
+| `service_name` | Identifying the generating application (OTel `service.name` — **required for Grafana Cloud correlation / App O11y**) |
+| `deployment_environment` | Deployment environment (OTel `deployment.environment`) — keep when present |
+| `job` | Collector / OTel job (`namespace/service.name` pattern common on span metrics) — keep when present |
+| `app` / `service` | Legacy aliases only — prefer aligning to `service_name`; do not delete without a migration plan |
+| `env` | Environment shorthand (prod, staging, dev) when `deployment_environment` is absent |
 | `cluster` | Multi-cluster differentiation |
 | `region` | Geographic region |
 | `level` | Log severity — normalize to: `info`, `warn`, `error`, `debug` |
-| `job` | Collector job name |
 | `team` / `squad` | Ownership (also useful for LBAC) |
 | `source` | Log origin type (`file`, `k8s-events`, `journal`, `syslog`, etc.) |
 | `classification` | Data sensitivity level — for LBAC policies |
+
+Always include allowlisted correlation labels in any `label_keep` list — see [references/protected-labels.md](references/protected-labels.md).
 
 ---
 
@@ -149,25 +165,25 @@ Every log source should consider these base labels — all low cardinality, high
 
 | Label | Description |
 |---|---|
+| `service_name` | Stable service identity (OTel `service.name`) — **keep**; remediate UUID/ephemeral values |
 | `namespace` | K8s namespace — delineates isolation boundaries |
 | `container` | Container name — low cardinality, differentiates log formats |
-| `service` | K8s service generating logs |
 | `workload` | `{controller_kind}/{controller_name}` e.g. `ReplicaSet/payment-api` — **strongly recommended** |
 
-**Why `workload` beats `app` for K8s**: Derived from `{{controller_kind}}/{{controller_name}}` — static values that never change like pod names do. Unlike `app` (which may aggregate multiple workload types), `workload` is precise and predictable. Users always know exactly what value to query.
+**Why `workload` beats `app` for K8s**: Derived from `{{controller_kind}}/{{controller_name}}` — static values that never change like pod names do. Unlike `app` (which may aggregate multiple workload types), `workload` is precise and predictable. Users always know exactly what value to query. Still keep `service_name` for cross-signal correlation even when using `workload`.
 
-### Labels to AVOID in Kubernetes
+### Labels to demote in Kubernetes (not "never existed")
 
-**`pod` label** ❌
+**`pod` label** ⚠️
 - Highly transient: pod names change on every restart/rollout
 - Very high cardinality: 5 pods × 2 containers = 10 streams; add `pod` → 10 × N streams
 - Users almost never query for a specific pod; they query for the *workload*
-- **Solution**: Use `workload` as the label; store `pod` in structured metadata or embed in the log line
+- **Solution**: Use `workload` as the index label; store `pod` in structured metadata or embed in the log line. Migrate any alerts/dashboards that select on `pod` before demoting.
 
-**`filename` label (raw K8s path)** ❌
+**`filename` label (raw K8s path)** ⚠️
 - K8s log paths contain pod UID: `/var/log/pods/{namespace}_{pod}_{pod_id}/{container}/{rotation}.log`
 - The `pod_id` component makes this unbounded
-- **Solution**: Normalize to `/var/log/pods/{namespace}/{controller_name}/{container}.log` or drop entirely
+- **Solution**: Normalize to `/var/log/pods/{namespace}/{controller_name}/{container}.log` or demote entirely after checking selectors
 
 ```alloy
 // Normalize K8s filename to remove pod UID
@@ -206,16 +222,14 @@ stage.replace {
 When collecting via `loki.source.journal`, many labels are auto-discovered under `__journal__*`:
 `boot_id`, `cap_effective`, `cmdline`, `comm`, `exe`, `gid`, `hostname`, `machine_id`, `pid`, `stream_id`, `systemd_cgroup`, `systemd_invocation_id`, `systemd_slice`, `systemd_unit`, `transport`, `uid`
 
-Almost all are high-cardinality. **Keep only**:
-- `instance` — hostname where journal logs were collected
-- `unit` — the `systemd_unit` name (e.g., `nginx.service`)
+Almost all are high-cardinality. **Keep** `instance` (hostname) and `unit` (`systemd_unit`, e.g. `nginx.service`), plus any allowlisted correlation labels present on the stream (`service_name`, `deployment_environment`, `job`).
 
-Drop everything else:
+Drop other non-allowlisted high-cardinality journal labels (not platform keys):
 ```alloy
 loki.process "journal_labels" {
  forward_to = [...]
  stage.label_keep {
- values = ["instance", "unit", "env", "cluster"]
+ values = ["instance", "unit", "env", "cluster", "service_name", "deployment_environment", "job"]
  }
 }
 ```
@@ -242,7 +256,7 @@ limits_config:
 
 Query structured metadata at query time without a parser:
 ```logql
-{app="payment-api"} | pod="payment-api-7f9d4b-xk2r9"
+{service_name="payment-api"} | pod="payment-api-7f9d4b-xk2r9"
 ```
 
 ---
@@ -337,27 +351,28 @@ When a user reports slow queries, identify where time is spent using Querier `me
 ```
 avg chunk size = total_bytes / cache_chunk_req
 ```
-If the result is a few hundred bytes or kilobytes (instead of megabytes), chunks are too small. This means labels are over-splitting data into too many streams. Revisit and reduce label cardinality.
+If the result is a few hundred bytes or kilobytes (instead of megabytes), chunks are too small. This means labels are over-splitting data into too many streams. Revisit cardinality — demote non-allowlisted high-card labels or stabilize protected-label values.
 
 ### Common Label-Related Performance Problems
 
 **Problem: Query scans too many streams**
 - Cause: High-cardinality labels exist but aren't specified in the query selector
-- Fix: Remove the label, or ensure queries always include it as a filter
+- Fix: Demote the label off the index after a migration check, or ensure queries always include it as a filter. Never demote allowlisted correlation labels — stabilize their values instead ([protected-labels.md](references/protected-labels.md))
 
 **Problem: High `post_filter_lines` discard ratio** (`post_filter_lines << total_lines`)
 - Cause: Insufficient label selectivity; query scans and discards most logs
-- Fix: Add labels matching user access patterns (`level`, `workload`, `container`)
+- Fix: Add labels matching user access patterns (`level`, `workload`, `container`, `service_name`)
 
 **Problem: Small chunks**
 - Cause: Too many labels creating too many fine-grained streams
-- Fix: Remove high-cardinality labels to consolidate streams
+- Fix: Demote high-cardinality non-allowlisted labels (e.g. `pod`) to consolidate streams; remediate protected-label *values* if they are the splitter
 
 ### Query Optimization Quick Wins
 1. Add `container` or `workload` to narrow scope before line filters
 2. Add `level` label + always use it in queries (filters out 94%+ of logs when searching for errors)
-3. Remove `pod` label → reduces stream count by ~5× in typical K8s deployments
+3. Demote `pod` off the index → reduces stream count by ~5× in typical K8s deployments (migrate selectors first)
 4. Replace regex line filters (`|~`) with exact filters (`|=`) where possible
+5. Keep `service_name` (and peers); if values are UUIDs/ephemeral, normalize to a stable identity — do not drop the key
 
 ---
 
@@ -392,12 +407,17 @@ loki.process "conditional_extraction" {
 
 ### Enforce Approved Label Set (always use as final stage)
 
+Always include allowlisted correlation labels when present — never omit `service_name`, `deployment_environment`, or `job` from `label_keep` ([protected-labels.md](references/protected-labels.md)):
+
 ```alloy
 loki.process "enforce_labels" {
  forward_to = [loki.write.default.receiver]
  // ... other stages ...
  stage.label_keep {
- values = ["app", "env", "cluster", "level", "namespace", "workload", "container"]
+ values = [
+ "service_name", "deployment_environment", "job",
+ "env", "cluster", "level", "namespace", "workload", "container",
+ ]
  }
 }
 ```
@@ -438,12 +458,12 @@ Static aggregate labels like `owner=sysadmins` or `category=database` are partic
 
 The most impactful improvements almost always come from these four changes:
 
-1. **Remove `pod` as a label** — biggest stream reduction in K8s environments
+1. **Demote `pod` off the index** (structured metadata) — biggest stream reduction in K8s; migrate selectors first
 2. **Add `level` as a label AND always specify it in queries** — can eliminate 94%+ of scanned data when searching for errors
-3. **Normalize label values** — eliminates phantom duplicate streams from inconsistent casing
-4. **Remove or normalize `filename`** in K8s — highly variable paths inflate stream count significantly
+3. **Normalize label values** — eliminates phantom duplicate streams from inconsistent casing; for `service_name`, stabilize UUID/ephemeral values (never drop the key)
+4. **Normalize or demote `filename`** in K8s — highly variable paths inflate stream count significantly
 
-Focus on these before anything else.
+Focus on these before anything else. Never "fix" cardinality by dropping `service_name`, `deployment_environment`, or `job`.
 
 ---
 
@@ -451,12 +471,15 @@ Focus on these before anything else.
 
 | Label | Why | Alternative |
 |---|---|---|
-| `pod` | Transient, unbounded | `workload` label + `pod` in structured metadata |
-| `user_id` | Unbounded | Keep only in log content |
-| `request_id` / `trace_id` | Unbounded | Structured metadata |
-| `filename` (raw K8s path) | Contains pod UID | Normalize or drop |
+| `pod` | Transient, high card | Demote: `workload` label + `pod` in structured metadata (migrate selectors) |
+| `user_id` | Unbounded — never valid as index label | Keep only in log content |
+| `request_id` / `trace_id` | Unbounded — never valid as index label | Structured metadata |
+| `filename` (raw K8s path) | Contains pod UID | Normalize or demote after selector check |
 | Unnormalized `level` | `INFO`/`info`/`Info` = 3 streams | Normalize at collection time |
+| UUID / ephemeral `service_name` *values* | Inflates streams; key is still required | Keep key; map values to stable service identity |
 | Any dynamically-named label key | Cannot be bounded | Use fixed keys with bounded values |
+
+**Never drop:** `service_name`, `deployment_environment`, `job` — see [references/protected-labels.md](references/protected-labels.md).
 
 ---
 

--- a/skills/grafana-cloud/loki-label-analyzer/references/protected-labels.md
+++ b/skills/grafana-cloud/loki-label-analyzer/references/protected-labels.md
@@ -1,0 +1,50 @@
+# Protected / Correlation Labels
+
+Hard never-drop allowlist for Grafana Cloud cross-signal correlation and Application Observability. Load this when evaluating any label for demotion or when writing `stage.label_keep` lists.
+
+## Allowlist (never drop the key)
+
+| Label | Source / notes |
+|---|---|
+| `service_name` | OTel `service.name` — joins logs, traces, metrics, service inventory, traces-to-logs |
+| `deployment_environment` | OTel `deployment.environment` — environment scoping in App O11y |
+| `job` | Often `service.namespace`/`service.name` — present on span metrics and many dashboards |
+
+If any of these keys exist on a stream, **keep them**. Cardinality problems on protected keys are **value** problems, not key problems.
+
+## Why dropping breaks things
+
+Grafana Cloud features and customer-owned artifacts select on these labels:
+
+- Application Observability service inventory and Logs panels (join on `service_name` / `service.name`)
+- Traces-to-logs and metrics-to-logs correlation
+- Alerts, dashboards, recording rules, and LBAC policies that already use these selectors
+
+Hard-dropping a protected key (or omitting it from `label_keep`) can silently break correlation and production selectors even when stream count improves.
+
+## Remediate values, not keys
+
+When a protected label has high cardinality (UUID `service_name`, short-lived job names, ephemeral environment strings):
+
+1. **Keep the label key**
+2. **Stabilize values** at collect time — map UUID / ephemeral names to a durable service identity (service catalog name, workload name, or OTel `service.name`)
+3. **Document the mapping** in Migration Notes so alerts and dashboards stay aligned
+4. Never recommend “remove `service_name`” (or peers) to fix cardinality
+
+Example audit action: `service_name` values look like UUIDs → Keep key | Normalize values to stable service identity (do not drop label).
+
+## Aliases (`app` / `service`)
+
+Prefer `service_name` for Grafana Cloud / OTel alignment. If the tenant only has `app` or `service`:
+
+- **Add or align** `service_name` to match OTel `service.name` across signals
+- Do **not** delete `app` / `service` without an explicit migration plan for existing selectors
+- Treat aliases as transitional, not as replacements for the allowlist
+
+## Downstream dependency guardrail
+
+Before recommending demotion or rename of **any** label (protected or not):
+
+- Call out alerts, dashboards, LBAC, and recording rules that may select on it
+- Require a Migration Notes plan (dual-write / add-then-cutover / update selectors)
+- Ask the user to confirm known dependencies when they are unknown — do not invent a clean cutover


### PR DESCRIPTION
Protect service_name, deployment_environment, and job; remediate high-cardinality values instead. Soften demote language for pod/filename so audits don't break App O11y, alerts, or dashboards.