### PR TITLE
feat(skills): add synthetic-monitoring-checks skill

### DIFF
--- a/.agents-plugin/marketplace.json
+++ b/.agents-plugin/marketplace.json
@@ -63,6 +63,7 @@
         "./skills/grafana-cloud/admin",
         "./skills/grafana-cloud/infrastructure",
         "./skills/grafana-cloud/testing",
+        "./skills/grafana-cloud/synthetic-monitoring-checks",
         "./skills/grafana-cloud/ml-ai",
         "./skills/grafana-cloud/app-observability",
         "./skills/grafana-cloud/database-observability",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,6 +63,7 @@
         "./skills/grafana-cloud/admin",
         "./skills/grafana-cloud/infrastructure",
         "./skills/grafana-cloud/testing",
+        "./skills/grafana-cloud/synthetic-monitoring-checks",
         "./skills/grafana-cloud/ml-ai",
         "./skills/grafana-cloud/app-observability",
         "./skills/grafana-cloud/database-observability",

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -63,6 +63,7 @@
         "./skills/grafana-cloud/admin",
         "./skills/grafana-cloud/infrastructure",
         "./skills/grafana-cloud/testing",
+        "./skills/grafana-cloud/synthetic-monitoring-checks",
         "./skills/grafana-cloud/ml-ai",
         "./skills/grafana-cloud/app-observability",
         "./skills/grafana-cloud/database-observability",

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Grafana Cloud — fleet management, cloud integrations, cost optimization, and A
 | [assistant-mcp](skills/grafana-cloud/assistant-mcp) | Connect AI coding agents (Claude Code, Cursor, Codex) to Grafana Cloud via MCP |
 | [private-connectivity](skills/grafana-cloud/private-connectivity) | Private network connectivity — AWS PrivateLink, Azure Private Link, GCP Private Service Connect |
 | [testing](skills/grafana-cloud/testing) | Synthetic Monitoring, k6 Cloud load testing, and Frontend Observability |
+| [synthetic-monitoring-checks](skills/grafana-cloud/synthetic-monitoring-checks) | Author Synthetic Monitoring checks — k6 scripted and browser check deep dive, check-type selection, API/Terraform |
 
 ### grafana-lgtm
 

--- a/skill-registry.json
+++ b/skill-registry.json
@@ -59,6 +59,12 @@
           "description": "Expert evaluator for Grafana Loki label strategy. Audits, designs, and improves label schemas using cardinality scoring, access-pattern alignment, static vs. dynamic label rules, and consistency checks. Use when the user asks to evaluate, audit, design, or improve a Loki label strategy — or asks why their Loki queries are slow.",
           "path": "skills/grafana-cloud/loki-label-analyzer",
           "tags": ["grafana-cloud", "loki", "logs", "labels", "cardinality", "alloy"]
+        },
+        {
+          "name": "synthetic-monitoring-checks",
+          "description": "Author Grafana Cloud Synthetic Monitoring checks — deep guidance for k6 scripted and browser checks, check-type selection, assertions that fail probe_success, secrets, and deployment via UI/API/Terraform. Use when writing a synthetic check, monitoring a login or checkout flow, converting a k6 script into a check, or validating a user journey in production. Not for load testing (use the grafana-k6 plugin).",
+          "path": "skills/grafana-cloud/synthetic-monitoring-checks",
+          "tags": ["grafana-cloud", "synthetic-monitoring", "k6", "browser-checks", "uptime", "checks", "terraform"]
         }
       ]
     },

--- a/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
+++ b/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
@@ -190,6 +190,11 @@ choose to convert:
 4. **Verify the target URL.** `servers:` blocks (and Postman environments) often list
    localhost or staging first — confirm the production base URL with the user, and map
    `securitySchemes` credentials to SM secrets, never to values inlined from the spec.
+5. **Treat `format: int64` ids as strings.** `res.json('id')` parses into a JS number
+   and silently corrupts values past 2^53 (snowflake-style ids), so the readback URL
+   404s on every execution while the create looks fine. Extract from the raw body
+   instead: `const id = (/"id":\s*(\d+)/.exec(res.body) || [])[1];` — and never do
+   arithmetic on it.
 
 No API spec at all? Probe the frontend: open the web app with browser devtools (or
 `curl` likely routes) and capture the `/api/*` XHR calls it makes — that's a monitorable
@@ -326,6 +331,7 @@ its configuration. Alerting: start with `alertSensitivity` / the default alert r
 | Check "fails" in your eyes but `probe_success` stays 1 | Bare `check()` without `fail()`/`expect()` — failures are recorded as metrics only. Convert to `expect()` or `check(...) \|\| fail(...)` |
 | Browser check flaps with locator timeouts | Brittle selectors or animation timing. Switch to `getByRole`/`getByTestId`, assert with auto-retrying `expect()`, remove manual waits |
 | `toBeVisible` reports `Expected: visible / Received: hidden` but the element is clearly visible | The locator matches multiple elements (strict mode) — the error message is misleading. Tighten the selector or use `.first()` |
+| Create succeeds but readback 404s on every execution | The id exceeds `Number.MAX_SAFE_INTEGER` (2^53) and `res.json()` silently rounded it — extract int64 ids from the raw body as strings (see the OpenAPI section) |
 | `secrets.get()` fails | Secret name mismatch (names are exact, ≤253 chars, letters/numbers/`-`/`_`), secret deleted (checks fail until recreated), or the editing user lacks the Admin/Editor role or "Checks writer" permission |
 | Executions time out but the journey is fine | Timeout too low for the journey (max 180s) — raise it; or the script does unbounded work per iteration. Also confirm timeout < frequency |
 | `Target has crashed` in browser check logs | Page exceeds the 1GB probe browser memory — trim the journey, block heavy third-party resources, or use a private probe with more memory |

--- a/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
+++ b/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: synthetic-monitoring-checks
+license: Apache-2.0
+description: >
+  Author Grafana Cloud Synthetic Monitoring checks, with deep coverage of k6 scripted and
+  browser checks: SM's single-VU/single-iteration execution model, assertions that actually
+  fail probe_success (expect() and fail() vs bare check()), secrets, deterministic scripts,
+  robust browser locators, local validation with k6 run, deployment via UI/API/Terraform,
+  verifying probe_success, and rollback. Also helps choose the simplest sufficient check
+  type (HTTP/ping/DNS/TCP, MultiHTTP, scripted, browser). Use when writing a synthetic
+  check, monitoring a login/checkout/signup flow in production, converting a k6 script or
+  an OpenAPI spec into a check, authoring a browser check, validating a user journey, or
+  asking "is my site up from multiple regions". NOT for load, stress, or performance testing — SM runs one
+  iteration per execution; for load tests use the grafana-k6 plugin or Grafana Cloud k6.
+  For the broad Grafana Cloud Testing overview (SM + k6 Cloud + Faro), use the testing skill.
+---
+
+# Synthetic Monitoring Check Authoring
+
+> **Docs**: https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/
+> Broad Grafana Cloud Testing entry point (SM + k6 Cloud + Faro): [`testing`](../testing/SKILL.md) skill.
+
+## Reliability monitoring, not load testing
+
+Synthetic Monitoring (SM) runs k6 as a **reliability/availability engine**: every check
+execution runs **one iteration with one VU** from each selected probe location on a fixed
+schedule. Success means "the user journey works right now, from this region" — detect
+outages before your customers do.
+
+Do **not** apply load-testing idioms. There are no VUs to ramp, no `stages`, no load
+profiles, no soak/stress/spike phases, and no `thresholds` over aggregated traffic.
+Vocabulary: *check*, *probe*, *execution*, *uptime*, *reachability*, *user journey
+validation* — never "load test", "ramping", or "VUs".
+
+**If the user actually wants load or performance testing** (throughput, latency under
+load, breakpoints), stop: that is Grafana Cloud k6 / the `grafana-k6` plugin's `k6` skill,
+not Synthetic Monitoring. A script can be shared between both products, but the goals,
+options, and pricing are different.
+
+## Execution model and constraints (verify against these before writing)
+
+| Constraint | Scripted & browser checks |
+|---|---|
+| Workload | 1 VU, 1 iteration per execution. `vus`, `duration`, `stages`, `iterations` are **ignored** |
+| `thresholds` | **Not supported** |
+| Frequency | 60–3600 seconds (MultiHTTP: 10–3600s) |
+| Timeout | 1–180 seconds — this is the max execution time (MultiHTTP: 1–60s) |
+| Local files | `open()`, `fs`, `grpc.load()` unsupported. Bundle local modules into the script; remote `https://jslib.k6.io/...` imports work |
+| HTTP request errors | SM runs k6 with `--throw`: network-level request failures throw an exception and fail the execution |
+| Supported options | `batch`, `batch-per-host`, `discardResponseBodies`, `httpDebug`, `insecureSkipTLSVerify`, `maxRedirects`, `noConnectionReuse`, `setupTimeout`, `systemTags`, `tags`, `teardownTimeout`, `throw`, `tlsAuth`, `tlsCipherSuites`, `tlsVersion`, `userAgent` — set only in the script's `options` object |
+| Browser memory | 1GB RAM per browser on public probes — huge pages fail with `Target has crashed` |
+| Browser script format | The UI rejects bundled/minified browser scripts (import validation) — deploy those via API or Terraform |
+
+## How an execution fails (this is what agents get wrong)
+
+`probe_success` (1/0) is the uptime signal. An execution is marked **failed** when the
+script throws an uncaught exception, calls `fail()`, a k6-testing `expect()` assertion
+fails, an HTTP request errors at the network level (`--throw`), or the timeout is hit.
+
+A **bare failed `check()` does NOT fail the execution** — it only records the
+`probe_checks_total` / `probe_check_success_rate` metrics. Checks don't affect k6's exit
+status without thresholds, and thresholds are disabled in SM.
+
+Assertion patterns, in order of preference:
+
+```javascript
+import { expect } from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';
+import { check, fail } from 'k6';
+
+// 1. PREFERRED — assertions module. Throws on failure => execution fails,
+//    with a descriptive error in the check logs.
+expect(res.status, 'login should succeed').toEqual(200);
+expect(res.json('token')).toBeDefined();
+
+// 2. Soft assertions — run all of them, still fail the execution at the end.
+expect.soft(res.headers['Content-Type']).toContain('application/json');
+
+// 3. check() when you also want per-assertion metrics — but pair it with
+//    fail() or the failure won't affect probe_success/uptime:
+check(res, { 'status 200': (r) => r.status === 200 }) ||
+  fail(`login failed with status ${res.status}`);
+```
+
+Name every assertion (the message argument / check name): the name is what you see in
+check logs and in the `check` label of `probe_checks_total` when diagnosing a failure
+at 3am.
+
+## Choose the simplest sufficient check type first
+
+Cheaper for the customer, easier to maintain. Work down this list and stop at the first
+match:
+
+1. **HTTP / ping / DNS / TCP / traceroute / gRPC** — a single static endpoint (uptime,
+   status code, body regex, TLS cert expiry, record resolution, port reachability). No
+   script to maintain — these run on the blackbox-exporter probe engine, and Terraform
+   examples with per-type `target` formats are in
+   [`references/api-and-terraform.md`](references/api-and-terraform.md).
+2. **MultiHTTP** — a sequence of HTTP requests with value-passing between them
+   (`${variable}` capture), but no custom logic. **Caution**: MultiHTTP does not
+   auto-validate status codes — define assertions per request or failures won't affect
+   uptime.
+3. **k6 scripted** — an API flow needing real logic: crypto/signing, conditional
+   branching, generated test data, WebSockets, response-driven chaining.
+4. **k6 browser** — only when you need a real browser: JS-rendered user journeys,
+   forms/clicks, Core Web Vitals.
+
+**Cost model** (execution-based billing): an execution is one check run on one probe,
+metered per minute of runtime rounded up. Per month:
+`probes × duration_minutes × (43200 / frequency_minutes)`. API test executions (HTTP,
+ping, DNS, TCP, traceroute, MultiHTTP, scripted) and browser test executions are billed
+separately — browser checks are the expensive tier. A browser check on 3 probes every
+minute is ~129,600 browser executions/month; the same check every 5 minutes is ~25,920.
+Pick the longest frequency that still meets your detection-time goal, and 2–3 probes
+near your users (multiple probes reduce alert flapping; more isn't better).
+
+## Scripted check authoring
+
+Skeleton — a login + API action journey with secrets and hard-failing assertions:
+
+```javascript
+import http from 'k6/http';
+import { expect } from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';
+import secrets from 'k6/secrets';
+
+const BASE = 'https://api.example.com';
+
+export default async function () {
+  // Secrets are managed in Synthetics > Config > Secrets — never hardcode credentials.
+  const password = await secrets.get('checkout-monitor-password');
+
+  // Step 1: authenticate with a dedicated monitoring account
+  const login = http.post(
+    `${BASE}/auth/login`,
+    JSON.stringify({ user: 'sm-checkout-monitor', password }),
+    { headers: { 'Content-Type': 'application/json' } }
+  );
+  expect(login.status, 'login should return 200').toEqual(200);
+  const token = login.json('token');
+  expect(token, 'auth token should be present').toBeDefined();
+
+  // Step 2: exercise the journey and assert the OUTCOME, not just the status
+  const order = http.post(`${BASE}/orders`, JSON.stringify({ sku: 'TEST-SKU-1', qty: 1 }), {
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+  });
+  expect(order.status, 'order should be created').toEqual(201);
+  const orderId = order.json('id');
+  expect(orderId, 'order id should be returned').toBeDefined();
+
+  // Step 3: clean up so the check is idempotent against production
+  // http.url groups metrics for URLs containing unique IDs — without it, every
+  // execution creates new time series (cardinality + active-series cost).
+  const del = http.del(http.url`${BASE}/orders/${orderId}`, null, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  expect(del.status, 'test order should be cleaned up').toEqual(204);
+}
+```
+
+Rules that make a scripted check a good *monitor* (vs a good test):
+
+- **Deterministic**: fixed test data (or generated-then-deleted, as above), no
+  time-of-day or ordering dependence. Every execution must be able to pass at any hour
+  from any probe.
+- **Idempotent against production**: create-then-delete, or use read-only endpoints.
+  The check runs forever — leaked state accumulates forever.
+- **Dedicated test account**: never a real user's credentials; scope it minimally, store
+  the password as an SM secret, and exclude the account from analytics/billing.
+- **Assert every step** — an unasserted step that breaks shows up as a *later* step's
+  confusing failure.
+- **Stable URL cardinality**: `http.url` template literal for any URL containing an ID.
+- Keep runtime well under the timeout, and the timeout under the frequency.
+
+### Generating a check from an OpenAPI spec (or similar)
+
+Given an API description — an OpenAPI/Swagger spec, GraphQL schema, or Postman
+collection — the mechanical conversion to k6 calls is easy. What matters is what you
+choose to convert:
+
+1. **Journeys, not endpoints.** Do NOT generate one check per path, or one check that
+   sweeps every path — that monitors the spec, not the service, and every extra check
+   multiplies execution cost. Identify the 1–3 flows whose failure means "customers are
+   impacted" (auth → core action → result) and write one scripted check per flow.
+2. **Filter for safety.** Only include mutating operations (`POST`/`PUT`/`DELETE`) when
+   the flow cleans up after itself (create-then-delete, as above) or targets dedicated
+   test resources. A spec lists destructive operations right next to health endpoints —
+   never exercise them against production just because they're documented.
+3. **Assert from the response schema.** The spec tells you exactly what a healthy
+   response contains — assert required fields, not just the status code:
+   `expect(order.json('id'), 'id required by OrdersResponse schema').toBeDefined()`.
+4. **Verify the target URL.** `servers:` blocks (and Postman environments) often list
+   localhost or staging first — confirm the production base URL with the user, and map
+   `securitySchemes` credentials to SM secrets, never to values inlined from the spec.
+
+No API spec at all? Probe the frontend: open the web app with browser devtools (or
+`curl` likely routes) and capture the `/api/*` XHR calls it makes — that's a monitorable
+HTTP surface even when the documented backend services are gRPC-only or internal.
+
+## Browser check authoring
+
+Required scaffold: import `k6/browser` and declare the `chromium` browser type. The UI
+validates both.
+
+```javascript
+import { browser } from 'k6/browser';
+import { expect } from 'https://jslib.k6.io/k6-testing/0.6.1/index.js';
+import secrets from 'k6/secrets';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: { browser: { type: 'chromium' } },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+  try {
+    await page.goto('https://shop.example.com/login');
+
+    // Prefer role/label/test-id locators over CSS chains — they survive redesigns.
+    const password = await secrets.get('shop-monitor-password');
+    await page.getByLabel('Email').fill('sm-monitor@example.com');
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    // Assert the JOURNEY OUTCOME with auto-retrying assertions — never sleep().
+    await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+
+    await page.getByRole('link', { name: 'Orders' }).click();
+    await expect(page.getByTestId('order-list')).toBeVisible();
+  } finally {
+    await page.close();
+  }
+}
+```
+
+Browser-specific rules:
+
+- **Locators**: `getByRole` / `getByLabel` / `getByTestId` (ask the app team to add
+  `data-testid` where needed) > text > CSS. Never XPath or generated class names.
+  `getByTestId` assumes `data-testid` — apps instrumented for Cypress often use
+  `data-cy` instead; fall back to `page.locator('[data-cy="..."]')`.
+- **No manual waits before interactions**: locator actions auto-wait for visibility and
+  enabled state. Don't call `waitFor()` before `click()`/`fill()`, don't use
+  `waitForLoadState()`, never `sleep()`.
+- **Auto-retrying `expect()`** (`toBeVisible`, `toBeEnabled`, ...) is the wait mechanism
+  for asserting state you don't interact with. Caveat: despite being listed as
+  retrying, the text matchers (`toHaveText`/`toContainText`) hard-fail on the first
+  *mismatched* read — e.g. an empty string mid-hydration on a client-rendered app.
+  Assert dynamic text by locating it and asserting visibility instead:
+  `await expect(page.getByText('Order confirmed')).toBeVisible()`.
+- **Assertion timeout defaults to 5s** — client-side-rendered apps routinely take
+  longer to first meaningful render. Raise it once and use the configured instance:
+  `const expectUi = expect.configure({ timeout: 20000 });`.
+- **Assert the outcome** (logged-in heading, order list, confirmation text) — a page can
+  load fine while the journey is broken.
+- **`try/finally` with `page.close()`** so the browser is released even when an
+  assertion throws.
+- Screenshot artifacts aren't a documented SM feature — don't build failure handling
+  around `page.screenshot()`; rely on assertion messages and the check's logs (SM stores
+  per-execution logs in Loki).
+- Web Vitals (`probe_browser_web_vital_lcp|cls|fcp|inp|ttfb`) are collected
+  automatically — no extra code needed.
+
+## Validate locally, then deploy
+
+SM scripts are plain k6 scripts — always run them locally first:
+
+```bash
+k6 run script.js                                              # scripted check
+K6_BROWSER_HEADLESS=true k6 run browser-check.js              # browser check
+k6 run --secret-source=mock=checkout-monitor-password=hunter2 script.js   # with secrets
+# Many/large secrets: k6 run --secret-source=file=secrets.txt script.js
+```
+
+Pass = exit code 0, one iteration, no failed assertions in the summary. Run it 3–5 times;
+a script that is 90% reliable locally will page you nightly from 3 probes.
+
+Then create the check (pick one):
+
+- **UI**: Testing & synthetics → Synthetics → Add new check → *k6 scripted* / *k6
+  browser* → paste script → select probes + frequency → **Test** (runs once without
+  saving) → Save.
+- **API or Terraform**: see [`references/api-and-terraform.md`](references/api-and-terraform.md).
+  Key gotchas: API `frequency`/`timeout` are **milliseconds** and `settings.scripted.script`
+  / `settings.browser.script` are **base64-encoded**; Terraform takes the plain script
+  via `file()`.
+
+## Verify it works, and rollback
+
+Wait one frequency interval, then in Explore against the Synthetic Monitoring metrics
+(Prometheus) datasource:
+
+```promql
+# 1 from every selected probe = healthy
+probe_success{job="checkout-flow"}
+
+# Assertion pass rate per named assertion (scripted/browser)
+probe_check_success_rate{job="checkout-flow"}
+
+# Journey duration per probe — confirm it's comfortably under the timeout
+probe_script_duration_seconds{job="checkout-flow"}
+
+# Uptime over time (how the SM app computes it)
+max by () (max_over_time(probe_success{job="checkout-flow"}[5m]))
+```
+
+A healthy first execution: `probe_success == 1` from every probe, all
+`probe_check_success_rate` series at 1, duration stable across probes, and the check's
+prebuilt dashboard (Synthetics → check → View dashboard) showing logs for each execution.
+Browser checks should additionally show `probe_browser_web_vital_*` series.
+
+**Rollback**: set the check's `enabled: false` (UI toggle, API update, or Terraform) to
+stop executions without losing history; delete the check only when you no longer need
+its configuration. Alerting: start with `alertSensitivity` / the default alert rules on
+`probe_success` — see the [`testing`](../testing/SKILL.md) skill for alert rule examples.
+
+## Common failure modes
+
+| Symptom | Cause → fix |
+|---|---|
+| Passes locally, fails on all probes | Target not reachable from the public internet (internal DNS, VPN, IP allowlist). Use [private probes](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/set-up/set-up-private-probes/) for internal targets, or allowlist probe egress |
+| Passes locally, fails on *some* probes | Geo-blocking, regional CDN/WAF rules, or bot protection challenging datacenter IPs. Check `probe` label on failures; exempt the SM `userAgent` or those regions in the WAF |
+| Check "fails" in your eyes but `probe_success` stays 1 | Bare `check()` without `fail()`/`expect()` — failures are recorded as metrics only. Convert to `expect()` or `check(...) \|\| fail(...)` |
+| Browser check flaps with locator timeouts | Brittle selectors or animation timing. Switch to `getByRole`/`getByTestId`, assert with auto-retrying `expect()`, remove manual waits |
+| `toBeVisible` reports `Expected: visible / Received: hidden` but the element is clearly visible | The locator matches multiple elements (strict mode) — the error message is misleading. Tighten the selector or use `.first()` |
+| `secrets.get()` fails | Secret name mismatch (names are exact, ≤253 chars, letters/numbers/`-`/`_`), secret deleted (checks fail until recreated), or the editing user lacks the Admin/Editor role or "Checks writer" permission |
+| Executions time out but the journey is fine | Timeout too low for the journey (max 180s) — raise it; or the script does unbounded work per iteration. Also confirm timeout < frequency |
+| `Target has crashed` in browser check logs | Page exceeds the 1GB probe browser memory — trim the journey, block heavy third-party resources, or use a private probe with more memory |
+| UI rejects a browser script | Bundled/minified script fails the UI's import validation — create it via API or Terraform instead |
+| Metrics/billing explosion after adding a check | Unique IDs in URLs creating per-execution time series — use `http.url`, and check frequency × probe count against the cost formula above |
+
+## References
+
+- [`references/api-and-terraform.md`](references/api-and-terraform.md) — SM API auth + check CRUD payloads (scripted, browser, MultiHTTP) and Terraform examples for every check type, including the protocol checks (HTTP, ping, DNS, TCP, traceroute, gRPC)
+
+## Resources
+
+- [Synthetic Monitoring docs](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/)
+- [k6 scripted checks](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6/) · [k6 browser checks](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6-browser/)
+- [Secrets management](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/manage-secrets/)
+- [k6 assertions (`expect`)](https://grafana.com/docs/k6/latest/using-k6/assertions/) · [k6 browser module](https://grafana.com/docs/k6/latest/using-k6-browser/)
+- k6 fundamentals and load testing: `grafana-k6` plugin, [`k6` skill](../../grafana-k6/k6/SKILL.md)

--- a/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
+++ b/skills/grafana-cloud/synthetic-monitoring-checks/SKILL.md
@@ -39,23 +39,25 @@ options, and pricing are different.
 
 ## Execution model and constraints (verify against these before writing)
 
-| Constraint | Scripted & browser checks |
+| Constraint | Value |
 |---|---|
-| Workload | 1 VU, 1 iteration per execution. `vus`, `duration`, `stages`, `iterations` are **ignored** |
+| Workload | One iteration per probe execution. Scripted and MultiHTTP run with forced `--vus 1 --iterations 1`; browser checks rely on the script's required single scenario. Either way `vus`, `duration`, `stages`, `iterations` are **ignored** — never write a load shape |
 | `thresholds` | **Not supported** |
-| Frequency | 60–3600 seconds (MultiHTTP: 10–3600s) |
-| Timeout | 1–180 seconds — this is the max execution time (MultiHTTP: 1–60s) |
+| Frequency | k6-class checks (scripted, MultiHTTP, browser): 60–3600s. Protocol checks (HTTP/ping/DNS/TCP/gRPC): 1–3600s. Traceroute: 120–3600s |
+| Timeout | Must be ≤ frequency. k6-class checks: 1–180s. Protocol checks: 1–60s. Traceroute: fixed 30s |
+| k6 version | Checks run on a [k6 version channel](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/manage-k6-versions/) (new checks default to the latest stable channel; `v1.x` is deprecated as of July 2026). Pin per check via the UI dropdown or `channels` in API/Terraform |
 | Local files | `open()`, `fs`, `grpc.load()` unsupported. Bundle local modules into the script; remote `https://jslib.k6.io/...` imports work |
 | HTTP request errors | SM runs k6 with `--throw`: network-level request failures throw an exception and fail the execution |
-| Supported options | `batch`, `batch-per-host`, `discardResponseBodies`, `httpDebug`, `insecureSkipTLSVerify`, `maxRedirects`, `noConnectionReuse`, `setupTimeout`, `systemTags`, `tags`, `teardownTimeout`, `throw`, `tlsAuth`, `tlsCipherSuites`, `tlsVersion`, `userAgent` — set only in the script's `options` object |
-| Browser memory | 1GB RAM per browser on public probes — huge pages fail with `Target has crashed` |
+| Script options SM honors | SM sets its own CLI flags, which take precedence over the script's `options` object; the options that still take effect include `batch`, `batch-per-host`, `discardResponseBodies`, `httpDebug`, `insecureSkipTLSVerify`, `maxRedirects`, `noConnectionReuse`, `setupTimeout`, `systemTags`, `tags`, `teardownTimeout`, `throw`, `tlsAuth`, `tlsCipherSuites`, `tlsVersion`, `userAgent` |
+| Browser memory | [1GB RAM per browser on public probes](https://grafana.com/docs/grafana-cloud/testing/synthetic-monitoring/create-checks/checks/k6-browser/#public-probe-memory) — huge pages fail with `Target has crashed` |
 | Browser script format | The UI rejects bundled/minified browser scripts (import validation) — deploy those via API or Terraform |
 
 ## How an execution fails (this is what agents get wrong)
 
 `probe_success` (1/0) is the uptime signal. An execution is marked **failed** when the
 script throws an uncaught exception, calls `fail()`, a k6-testing `expect()` assertion
-fails, an HTTP request errors at the network level (`--throw`), or the timeout is hit.
+fails (it calls k6's `test.abort()` under the hood), an HTTP request errors at the
+network level (SM's `--throw`), or the timeout is hit.
 
 A **bare failed `check()` does NOT fail the execution** — it only records the
 `probe_checks_total` / `probe_check_success_rate` metrics. Checks don't affect k6's exit
@@ -190,6 +192,8 @@ choose to convert:
 4. **Verify the target URL.** `servers:` blocks (and Postman environments) often list
    localhost or staging first — confirm the production base URL with the user, and map
    `securitySchemes` credentials to SM secrets, never to values inlined from the spec.
+   (Secrets in plain HTTP/protocol checks are a recent, feature-flagged rollout — check
+   current docs; the scripted `secrets.get()` path always works.)
 5. **Treat `format: int64` ids as strings.** `res.json('id')` parses into a JS number
    and silently corrupts values past 2^53 (snowflake-style ids), so the readback URL
    404s on every execution while the create looks fine. Extract from the raw body
@@ -276,7 +280,7 @@ SM scripts are plain k6 scripts — always run them locally first:
 ```bash
 k6 run script.js                                              # scripted check
 K6_BROWSER_HEADLESS=true k6 run browser-check.js              # browser check
-k6 run --secret-source=mock=checkout-monitor-password=hunter2 script.js   # with secrets
+k6 run --secret-source=mock=checkout-monitor-password=example-password script.js   # with secrets
 # Many/large secrets: k6 run --secret-source=file=secrets.txt script.js
 ```
 

--- a/skills/grafana-cloud/synthetic-monitoring-checks/references/api-and-terraform.md
+++ b/skills/grafana-cloud/synthetic-monitoring-checks/references/api-and-terraform.md
@@ -138,7 +138,7 @@ terraform {
   required_providers {
     grafana = {
       source  = "grafana/grafana"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }
@@ -218,6 +218,63 @@ resource "grafana_synthetic_monitoring_check" "login_journey_browser" {
 
 Terraform is also the standard workaround for bundled/minified browser scripts that the
 UI's import validation rejects.
+
+### MultiHTTP in Terraform
+
+Unlike the API, Terraform takes the assertion and variable enums as **strings**
+(`TEXT`, `HTTP_STATUS_CODE`, `EQUALS`, `JSON_PATH`, ...) — same names as the protobuf,
+no numbers needed:
+
+```hcl
+resource "grafana_synthetic_monitoring_check" "api_flow" {
+  job       = "api-flow"
+  target    = "https://api.example.com/auth"
+  frequency = 120000
+  timeout   = 30000
+  probes    = [data.grafana_synthetic_monitoring_probes.main.probes.Ohio]
+
+  settings {
+    multihttp {
+      entries {
+        request {
+          method = "POST"
+          url    = "https://api.example.com/auth"
+        }
+        assertions {
+          type      = "TEXT"
+          subject   = "HTTP_STATUS_CODE"
+          condition = "EQUALS"
+          value     = "200"
+        }
+        variables {
+          type       = "JSON_PATH"
+          name       = "token"
+          expression = "$.token"
+        }
+      }
+      entries {
+        request {
+          method = "GET"
+          url    = "https://api.example.com/orders"
+          headers {
+            name  = "Authorization"
+            value = "Bearer $${token}"
+          }
+        }
+        assertions {
+          type      = "TEXT"
+          subject   = "HTTP_STATUS_CODE"
+          condition = "EQUALS"
+          value     = "200"
+        }
+      }
+    }
+  }
+}
+```
+
+(`$${token}` is Terraform escaping for a literal `${token}` — SM interpolates the
+variable at probe time.)
 
 ### Protocol (blackbox-exporter) checks in Terraform
 

--- a/skills/grafana-cloud/synthetic-monitoring-checks/references/api-and-terraform.md
+++ b/skills/grafana-cloud/synthetic-monitoring-checks/references/api-and-terraform.md
@@ -1,0 +1,293 @@
+# Synthetic Monitoring checks as code — API and Terraform
+
+## API authentication
+
+Two things are needed (both from **Testing & synthetics → Synthetics → Config**):
+
+- **Access token** — Config → *Access tokens* tab → Generate access token.
+- **Backend address** — Config → *General* tab, "Your backend address is", e.g.
+  `synthetic-monitoring-api-us-east-0.grafana.net`. It is region-specific to your stack.
+
+```bash
+SM_API="https://synthetic-monitoring-api-us-east-0.grafana.net"  # your backend address
+SM_TOKEN="<sm-access-token>"
+```
+
+Full endpoint list: OpenAPI spec at `https://synthetic-monitoring-api.grafana.net/api/v1/swagger`.
+
+## Check endpoints
+
+| Operation | Endpoint |
+|---|---|
+| List checks | `GET /api/v1/check` |
+| Create check | `POST /api/v1/check` |
+| Get check | `GET /api/v1/check/{id}` |
+| Update check | `POST /api/v1/check/{id}` (send the full check object incl. `id` and `tenantId`) |
+| Delete check | `DELETE /api/v1/check/{id}` |
+| Run once without saving | `POST /api/v1/check/adhoc` |
+| List probes (get IDs for `probes`) | `GET /api/v1/probe` |
+
+API payload gotchas (differ from the UI):
+
+- `frequency` and `timeout` are in **milliseconds** (UI shows seconds).
+- `settings.scripted.script` and `settings.browser.script` are **base64-encoded**
+  (`format: byte` in the OpenAPI spec). Plain-text scripts are rejected or corrupted.
+- `probes` is an array of numeric probe IDs — resolve names via `GET /api/v1/probe`.
+
+## Create a scripted check
+
+```bash
+jq -n --rawfile script check.js '{
+  job: "checkout-flow",
+  target: "checkout-flow",
+  enabled: true,
+  frequency: 300000,
+  timeout: 90000,
+  probes: [1, 5],
+  labels: [{ name: "env", value: "production" }],
+  settings: { scripted: { script: ($script | @base64) } }
+}' | curl -sS -X POST "$SM_API/api/v1/check" \
+  -H "Authorization: Bearer $SM_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @-
+```
+
+A browser check is identical except for the settings key:
+`settings: { browser: { script: ($script | @base64) } }` (and remember browser
+executions are billed at the browser rate).
+
+## Create a MultiHTTP check
+
+MultiHTTP assertions use numeric enums in the API (the UI hides this). Enum values, from
+the [check protobuf definition](https://github.com/grafana/synthetic-monitoring-agent/blob/main/pkg/pb/synthetic_monitoring/checks.proto):
+
+| Field | Values |
+|---|---|
+| `checks[].type` | 0 TEXT · 1 JSON_PATH_VALUE · 2 JSON_PATH_ASSERTION · 3 REGEX_ASSERTION |
+| `checks[].subject` | 0 DEFAULT (body) · 1 RESPONSE_HEADERS · 2 HTTP_STATUS_CODE · 3 RESPONSE_BODY |
+| `checks[].condition` | 1 NOT_CONTAINS · 2 EQUALS · 3 STARTS_WITH · 4 ENDS_WITH · 5 TYPE_OF · 6 CONTAINS |
+| `variables[].type` | 0 JSON_PATH · 1 REGEX · 2 CSS_SELECTOR |
+
+Minimal two-request example — POST for a token, then use it (each request asserts
+status 200: TEXT assertion on HTTP_STATUS_CODE EQUALS "200"):
+
+```bash
+curl -sS -X POST "$SM_API/api/v1/check" \
+  -H "Authorization: Bearer $SM_TOKEN" -H "Content-Type: application/json" -d '{
+  "job": "api-flow",
+  "target": "https://api.example.com/auth",
+  "enabled": true,
+  "frequency": 120000,
+  "timeout": 30000,
+  "probes": [1, 5],
+  "settings": {
+    "multihttp": {
+      "entries": [
+        {
+          "request": { "method": "POST", "url": "https://api.example.com/auth" },
+          "checks": [
+            { "type": 0, "subject": 2, "condition": 2, "value": "200" }
+          ],
+          "variables": [
+            { "type": 0, "name": "token", "expression": "$.token" }
+          ]
+        },
+        {
+          "request": {
+            "method": "GET",
+            "url": "https://api.example.com/orders",
+            "headers": [{ "name": "Authorization", "value": "Bearer ${token}" }]
+          },
+          "checks": [
+            { "type": 0, "subject": 2, "condition": 2, "value": "200" }
+          ]
+        }
+      ]
+    }
+  }
+}'
+```
+
+For complex MultiHTTP checks, the safest path is to build one in the UI and
+`GET /api/v1/check/{id}` to copy its JSON.
+
+Remember: MultiHTTP requests without `checks` entries do not affect uptime — always
+assert at least the status code per request.
+
+## Update, disable, delete
+
+```bash
+# Fetch, flip enabled=false (rollback without losing config), push back
+curl -sS "$SM_API/api/v1/check/123" -H "Authorization: Bearer $SM_TOKEN" \
+  | jq '.enabled = false' \
+  | curl -sS -X POST "$SM_API/api/v1/check/123" \
+      -H "Authorization: Bearer $SM_TOKEN" -H "Content-Type: application/json" -d @-
+
+# Delete permanently
+curl -sS -X DELETE "$SM_API/api/v1/check/123" -H "Authorization: Bearer $SM_TOKEN"
+```
+
+## Terraform
+
+`grafana_synthetic_monitoring_check` takes the plain script (the provider handles
+encoding). `frequency`/`timeout` are milliseconds, `probes` is required, and probe IDs
+resolve via the probes data source.
+
+```hcl
+terraform {
+  required_providers {
+    grafana = {
+      source  = "grafana/grafana"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "sm_access_token" {
+  type      = string
+  sensitive = true
+}
+
+provider "grafana" {
+  sm_access_token = var.sm_access_token
+  sm_url          = "https://synthetic-monitoring-api-us-east-0.grafana.net" # your backend address
+}
+
+data "grafana_synthetic_monitoring_probes" "main" {}
+
+# Simplest sufficient type first: a plain HTTP check needs no script at all.
+resource "grafana_synthetic_monitoring_check" "api_health" {
+  job       = "api-health"
+  target    = "https://api.example.com/health"
+  enabled   = true
+  frequency = 60000 # ms
+  timeout   = 5000  # ms
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
+  ]
+
+  settings {
+    http {
+      method              = "GET"
+      valid_status_codes  = [200]
+      valid_http_versions = ["HTTP/1.1", "HTTP/2.0"]
+      fail_if_not_ssl     = true
+    }
+  }
+}
+
+resource "grafana_synthetic_monitoring_check" "checkout_flow" {
+  job       = "checkout-flow"
+  target    = "checkout-flow"
+  enabled   = true
+  frequency = 300000 # ms — every 5 minutes
+  timeout   = 90000  # ms — must cover the whole journey (max 180000)
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
+    data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt,
+  ]
+  labels = {
+    env = "production"
+  }
+
+  settings {
+    scripted {
+      script = file("${path.module}/scripts/checkout-flow.js")
+    }
+  }
+}
+
+resource "grafana_synthetic_monitoring_check" "login_journey_browser" {
+  job       = "login-journey"
+  target    = "https://shop.example.com/login"
+  enabled   = true
+  frequency = 600000 # ms — browser executions are the expensive tier; be deliberate
+  timeout   = 120000 # ms
+  probes = [
+    data.grafana_synthetic_monitoring_probes.main.probes.Ohio,
+  ]
+
+  settings {
+    browser {
+      script = file("${path.module}/scripts/login-journey.js")
+    }
+  }
+}
+```
+
+Terraform is also the standard workaround for bundled/minified browser scripts that the
+UI's import validation rejects.
+
+### Protocol (blackbox-exporter) checks in Terraform
+
+The simple check types — HTTP, ping, DNS, TCP, traceroute, gRPC — need no script and are
+the bulk of most fleets. Two things agents get wrong:
+
+- `settings` must contain **exactly one** nested block, even with all defaults:
+  `settings { ping {} }` is valid and required — an empty `settings {}` is not.
+- The `target` format differs per type:
+
+| Type | `target` format | Key settings fields |
+|---|---|---|
+| `http` | Full URL `https://example.com/health` | `valid_status_codes`, `fail_if_not_ssl`, `fail_if_body_not_matches_regexp`, `headers`, `basic_auth` |
+| `ping` | Hostname `example.com` | usually none (`ping {}`) |
+| `dns` | Record to resolve `example.com` | `server` (default `8.8.8.8`), `record_type` (default `A`), `valid_r_codes`, `validate_answer_rrs` |
+| `tcp` | `host:port` `example.com:443` | `tls`, `query_response { send / expect / start_tls }` |
+| `traceroute` | Hostname `example.com` | `max_hops`, `max_unknown_hops`, `ptr_lookup` |
+| `grpc` | `host:port` | `service` (health-check service name), `tls`, `tls_config` |
+
+```hcl
+# DNS: assert the record resolves against your own nameserver with NOERROR
+resource "grafana_synthetic_monitoring_check" "dns_www" {
+  job       = "dns-www"
+  target    = "www.example.com"
+  frequency = 120000
+  timeout   = 5000
+  probes    = [data.grafana_synthetic_monitoring_probes.main.probes.Ohio]
+
+  settings {
+    dns {
+      server        = "ns1.example.com"
+      record_type   = "A"
+      valid_r_codes = ["NOERROR"]
+    }
+  }
+}
+
+# TCP with TLS: also feeds probe_ssl_earliest_cert_expiry for cert-expiry alerting
+resource "grafana_synthetic_monitoring_check" "smtp" {
+  job       = "smtp-tls"
+  target    = "mail.example.com:465"
+  frequency = 300000
+  timeout   = 5000
+  probes    = [data.grafana_synthetic_monitoring_probes.main.probes.Frankfurt]
+  alert_sensitivity = "high"
+
+  settings {
+    tcp {
+      tls = true
+    }
+  }
+}
+
+# Ping and traceroute need only the empty block
+resource "grafana_synthetic_monitoring_check" "edge_ping" {
+  job       = "edge-ping"
+  target    = "edge.example.com"
+  frequency = 60000
+  timeout   = 3000
+  probes    = [data.grafana_synthetic_monitoring_probes.main.probes.Ohio]
+
+  settings {
+    ping {}
+  }
+}
+```
+
+Other top-level fields worth setting as-code: `alert_sensitivity` (`none` default —
+set `low`/`medium`/`high` to feed the prebuilt `probe_success` alert rules) and
+`basic_metrics_only` (defaults to `true`; set `false` only if you need the full
+blackbox-exporter metric set).
+
+Resource docs: https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/synthetic_monitoring_check

--- a/skills/grafana-cloud/testing/SKILL.md
+++ b/skills/grafana-cloud/testing/SKILL.md
@@ -93,6 +93,7 @@ faro.api.pushEvent('faro_smoketest', { ts: Date.now().toString() });
 
 ## References
 
+- For deep authoring of Synthetic Monitoring scripted (k6) and browser checks — execution model, assertions, secrets, API/Terraform payloads — see the [`synthetic-monitoring-checks`](../synthetic-monitoring-checks/SKILL.md) skill
 - [`references/synthetic.md`](references/synthetic.md) — Synthetic Monitoring essentials: check types, key PromQL metrics, alert rules
 - [`references/synthetic-monitoring.md`](references/synthetic-monitoring.md) — deep dive: full API for check CRUD, probe selection, scripted (k6) checks, multi-step browser checks
 - [`references/k6-and-faro.md`](references/k6-and-faro.md) — k6 cloud script + Faro Web SDK init snippets for end-to-end testing


### PR DESCRIPTION
## Summary

New `grafana-cloud` skill: **`synthetic-monitoring-checks`** — deep guidance for authoring Grafana Cloud Synthetic Monitoring checks, with emphasis on k6 scripted and browser checks. Registered in all three marketplace manifests, `skill-registry.json`, and the README.

What it covers:
- **SM's execution model** and the constraints agents trained on k6 load-testing content get wrong: single VU / single iteration per probe execution, no `scenarios`/`stages`/`thresholds`, 60–3600s frequency, 1–180s timeout, no local file access, SM's implicit `--throw`.
- **How `probe_success` is actually determined**: a bare failed `check()` records metrics but does **not** fail the execution — use k6-testing `expect()` (throws) or `check(...) || fail(...)`. Verified in the synthetic-monitoring-agent source and reproduced empirically (failed `expect()` → exit 108; bare failed `check()` → exit 0).
- Check-type decision guide biased toward the *simplest sufficient type* (protocol checks → MultiHTTP → scripted → browser), with the execution-based cost formula (frequency × probes × duration; API vs browser executions billed separately).
- Scripted-check authoring: secrets (`k6/secrets`), determinism/idempotency against production, dedicated test accounts, `http.url` cardinality control, generating checks from an OpenAPI spec (journeys not endpoints, safety filtering, schema-driven assertions).
- Browser-check authoring: role/label/test-id locators, auto-retrying assertions — including real-world caveats found in field testing (text matchers hard-fail on first mismatched read, strict-mode multi-match reports a misleading `Received: hidden`, 5s default assertion timeout).
- Validate locally with `k6 run` (incl. `--secret-source=mock`), deploy via UI/API/Terraform, verify `probe_success`, rollback via `enabled: false`.
- `references/api-and-terraform.md`: SM API auth + CRUD payloads (base64 `script` fields, ms units, MultiHTTP assertion enums from the check protobuf) and `terraform validate`-passing examples for **every** check type, including the blackbox-exporter protocol checks (HTTP, DNS, TCP, ping, traceroute, gRPC) with per-type `target` formats.

## Motivation

**Why separate from `testing`?** The existing `testing` skill is the broad Grafana Cloud Testing entry point (SM + k6 Cloud + Faro) and stays that way — this skill goes deep on *authoring checks*, which doesn't fit in a survey skill. The two cross-reference each other.

**Why deliberately not a load-testing skill?** SM runs k6 as a reliability/availability engine, and agents default to load-testing idioms that are invalid or harmful in SM (ramping VUs, thresholds, load-test vocabulary). The skill enforces the distinction throughout and redirects load/performance asks to the `grafana-k6` plugin — both in the body and in the frontmatter description so the wrong skill doesn't auto-load.

**What was verified rather than recalled:**
- Limits, supported k6 options, module restrictions, secrets API, and billing model against current grafana.com docs.
- Failure semantics against `grafana/synthetic-monitoring-agent` source (`k6runner`, `--throw`, error-code mapping) plus local reproduction with k6 v1.7.1.
- `toHaveText`/timeout/abort behavior against `grafana/k6-jslib-testing` v0.6.1 source.
- API payload shapes against the live SM OpenAPI spec (`/api/v1/openapi.json`); MultiHTTP assertion enums against the check protobuf.
- All Terraform examples pass `terraform validate` verbatim against the current grafana provider; all k6 examples pass `k6 inspect`, and the assertion/secrets patterns were run end-to-end against QuickPizza.
- Field-tested from a fresh session: handed only the URL of an OTel demo deployment, the skill produced working checks; the friction found (text-matcher retries, strict mode, assertion timeout, `data-cy`, missing HTTP Terraform example, undeclared TF variable) is folded back in.

## Test plan

- [x] `./scripts/lint-skills.sh skills/grafana-cloud` — passes, 0 errors / 0 warnings (SKILL.md 345 lines)
- [x] Three marketplace manifests identical; `skill-registry.json` and README updated
- [x] `terraform validate` on the reference's HCL, `k6 inspect` + end-to-end runs on the JS examples
- [ ] Reviewer spot-check: description triggers load correctly and a load-testing prompt does *not* pull this skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)