### PR TITLE
Bump pinned tesslio/skill-review SHA to the current release

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -52,7 +52,7 @@ jobs:
         # Pin includes scoreBar fix for rubric scale 1-5 (tesslio/skill-review#18).
         # Older pins crash with String.prototype.repeat RangeError when a
         # dimension score exceeds the old hardcoded max of 3.
-        uses: tesslio/skill-review@5aefcf5e500ae13a9af904383dbb914c6c3a50e4 # main @ 2026-07-22
+        uses: tesslio/skill-review@7e7ea574722a6d72752aa5a316bcc813d06b7cd2 # main @ 2026-07-31
         with:
           comment: 'false'
           # Block PR merge on scores below 75. Anthropic best-practice baseline


### PR DESCRIPTION
Hi 👋 I'm Alan from Tessl — thanks for running our `skill-review` action in grafana/skills; it's one of the most active and cleanly set-up uses we see (nice Vault-managed token wiring 👏).

This is a heads-up rather than a fire: your workflow pins `@5aefcf5` (`# main @ 2026-07-22`), which is just before we migrated the action to Tessl Review on 30–31 Jul. It's green today, but that pin will drift out of support as the CLI and rubric move on. This PR bumps it to the current release commit (`7e7ea57`, 31 Jul) and updates the date comment to match. Your token + workspace wiring is unchanged.

(The action isn't tagged yet, so a commit SHA is the right thing to pin — happy to give you a heads-up here whenever we cut the next one.)

Thanks for building with Tessl! 🙏 — Alan
