### PR TITLE
Add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,4 @@ Any tool supporting the [Agent Skills](https://agentskills.io) standard or the `
 - [Agent Skills Standard](https://agentskills.io)
 - [Agent Skills Specification](https://agentskills.io/specification)
 - [Anthropic Skills Repository](https://github.com/anthropics/skills)
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
